### PR TITLE
Fix z scale

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8561,6 +8561,18 @@ def runGeneration(type):
         convert_to_blender_coordinates(lat, lon, ele, timestamp)
         for lat, lon, ele, timestamp in coordinates
     ]
+    _g_slopes = []
+    _all_segs = blender_coords_separate if blender_coords_separate else [blender_coords]
+    for _seg in _all_segs:
+        for _i in range(len(_seg) - 1):
+            x1, y1, z1 = _seg[_i]
+            x2, y2, z2 = _seg[_i+1]
+            _h = math.sqrt((x2-x1)**2 + (y2-y1)**2)
+            if _h > 0:
+                _g_slopes.append(abs(z2 - z1) / _h)
+    if _g_slopes:
+        _avg_g = sum(_g_slopes) / len(_g_slopes)
+        print(f"[DEBUG] GPX avg slope:     {_avg_g:.4f}  ({math.degrees(math.atan(_avg_g)):.2f}°)")
     blender_coords = simplify_curve(blender_coords, .12)
     blender_coords = separate_duplicate_xy(blender_coords, 0.05)
     if ("separate_paths" in flags or len(separate_paths) > 1) and "trail_map" not in flags:
@@ -8632,8 +8644,13 @@ def runGeneration(type):
     lowestZ  = 1000
     highestZ = 0
     _total_verts = len(mesh.vertices)
+    _obj_matrix = MapObject.matrix_world
+    _elev_scale = props['scaleElevation'] * autoScale / 1000
     for i, vert in enumerate(mesh.vertices):
-        vert.co.z = tileVerts[i] / 1000 * props['scaleElevation'] * autoScale
+        _world_co = _obj_matrix @ vert.co
+        _vert_lat, _ = convert_to_geo(_world_co.x, _world_co.y)
+        _merc = 1 / math.cos(math.radians(_vert_lat))
+        vert.co.z = tileVerts[i] * _elev_scale * _merc
         lowestZ  = min(lowestZ,  vert.co.z)
         highestZ = max(highestZ, vert.co.z)
         if i % 5000 == 0:
@@ -8648,6 +8665,16 @@ def runGeneration(type):
     print(f"additionalExtrusion: {additionalExtrusion}")
     print(f"Lowest z: {lowestZ}")
     print(f"Highest z: {highestZ}")
+    _t_slopes = []
+    for edge in mesh.edges:
+        v1 = mesh.vertices[edge.vertices[0]].co
+        v2 = mesh.vertices[edge.vertices[1]].co
+        _h = math.sqrt((v2.x-v1.x)**2 + (v2.y-v1.y)**2)
+        if _h > 0:
+            _t_slopes.append(abs(v2.z - v1.z) / _h)
+    if _t_slopes:
+        _avg_t = sum(_t_slopes) / len(_t_slopes)
+        print(f"[DEBUG] Terrain avg slope: {_avg_t:.4f}  ({math.degrees(math.atan(_avg_t)):.2f}°)")
 
 
     # Snap trail curves onto terrain surface

--- a/utils.py
+++ b/utils.py
@@ -8647,7 +8647,7 @@ def runGeneration(type):
     _obj_matrix = MapObject.matrix_world
     for i, vert in enumerate(mesh.vertices):
         _world_co = _obj_matrix @ vert.co
-        _vert_lat, _ = convert_to_geo(_world_co.x, _world_co.y)
+        _vert_lat, _unused_var = convert_to_geo(_world_co.x, _world_co.y)
         _merc = 1 / math.cos(math.radians(_vert_lat))
         vert.co.z = tileVerts[i] / 1000 * props['scaleElevation'] * autoScale * _merc 
         lowestZ  = min(lowestZ,  vert.co.z)

--- a/utils.py
+++ b/utils.py
@@ -8645,12 +8645,11 @@ def runGeneration(type):
     highestZ = 0
     _total_verts = len(mesh.vertices)
     _obj_matrix = MapObject.matrix_world
-    _elev_scale = props['scaleElevation'] * autoScale / 1000
     for i, vert in enumerate(mesh.vertices):
         _world_co = _obj_matrix @ vert.co
         _vert_lat, _ = convert_to_geo(_world_co.x, _world_co.y)
         _merc = 1 / math.cos(math.radians(_vert_lat))
-        vert.co.z = tileVerts[i] * _elev_scale * _merc
+        vert.co.z = tileVerts[i] / 1000 * props['scaleElevation'] * autoScale * _merc 
         lowestZ  = min(lowestZ,  vert.co.z)
         highestZ = max(highestZ, vert.co.z)
         if i % 5000 == 0:


### PR DESCRIPTION
## What does this PR do?

Fixes the z scale.
While x and y are scaled to fix issues with Mercator projection, the z was not also scaled accordingly.

Issue described in Discord: 
https://discord.com/channels/1363264649612759301/1363266758068404315/1485594877017194526

tried to fix it in convert_to_blender_coordinates() as you said in https://discord.com/channels/1363264649612759301/1363266758068404315/1486783000032182495
but that z does not seem to be used in the final elevation. 

now the fix is at Phase 11: Apply terrain elevation to mesh vertices.

how the difference looks in blender:

<img width="1100" height="931" alt="2026-04-28_16-00" src="https://github.com/user-attachments/assets/f6073ab7-20ed-4fd4-8f74-b868774a4360" />

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update

## Related issue

created a PR instead of a Issue.

## How was it tested?

Tested with a GPX from northern Norway as the mismatch is larger the farther the GPX is from the equator.
Had a debug code in f7f565c
[DEBUG] Terrain avg slope: ...
[DEBUG] GPX avg slope: ...
to verify the mismatch and the correction

tested in blender 5.0.1

## Checklist

- [x] I tested this in Blender 5.0 or newer
- [x] I haven't broken any existing features I'm aware of
- [x] New or changed behaviour is reflected in the README (if relevant)