### PR TITLE
Parallelize OSM fetching, improve mesh/terrain ops

### DIFF
--- a/TrailPrint3D/constants.py
+++ b/TrailPrint3D/constants.py
@@ -41,6 +41,9 @@ terrarium_cache_dir = os.path.join(bpy.utils.user_resource('CONFIG'), "TrailPrin
 # Set up a cache for Overpass Files
 overpass_cache_dir = os.path.join(bpy.utils.user_resource('CONFIG'), "TrailPrint3D_Cache","overpass_cache")
 
+# Set up a cache for computed elevation arrays (per-map vertex elevations)
+elevation_results_dir = os.path.join(bpy.utils.user_resource('CONFIG'), "TrailPrint3D_Cache","elevation_results")
+
 #Set up a folder for Presets
 preset_dir = os.path.join(bpy.utils.user_resource('CONFIG'), "TP3D-presets")
 
@@ -50,6 +53,7 @@ def _ensure_dirs():
     os.makedirs(cache_dir, exist_ok=True)
     os.makedirs(terrarium_cache_dir, exist_ok=True)
     os.makedirs(overpass_cache_dir, exist_ok=True)
+    os.makedirs(elevation_results_dir, exist_ok=True)
     os.makedirs(preset_dir, exist_ok=True)
 
 

--- a/TrailPrint3D/operators.py
+++ b/TrailPrint3D/operators.py
@@ -309,6 +309,14 @@ class TP3D_OT_clear_cache(bpy.types.Operator):
         except Exception as e:
             print(f"Failed to delete cache directory: {e}")
 
+        # Clear the in-memory elevation cache so the load guard doesn't
+        # serve stale data after the files have been deleted.
+        const._elevation_cache.clear()
+
+        # Recreate the directory tree so save_elevation_cache() doesn't
+        # silently fail trying to write into a path that no longer exists.
+        const._ensure_dirs()
+
         return {'FINISHED'}
 
 

--- a/TrailPrint3D/utils/elevation.py
+++ b/TrailPrint3D/utils/elevation.py
@@ -181,7 +181,10 @@ def get_elevation_openTopoData(coords, lenv = 0, pointsDone = 0, progress_cb=Non
             elevation = result.get('elevation', None)  # Safe get, default to None if key is missing
             if elevation is None:
                 elevation = 0  # Replace None (null in JSON) with 0
-            cache_elevation(batch[o][0], batch[o][1], elevation)
+            else:
+                # Only cache real values — null responses (stored as 0) would poison the cache
+                # and cause silent all-zero terrain on subsequent runs.
+                cache_elevation(batch[o][0], batch[o][1], elevation)
             ind = coords_indices[i+o]
             elevations[ind] = elevation
 

--- a/TrailPrint3D/utils/elevation.py
+++ b/TrailPrint3D/utils/elevation.py
@@ -626,28 +626,19 @@ def _elevation_results_key(minLat, maxLat, minLon, maxLon, api, num_subdivisions
     return os.path.join(const.elevation_results_dir, f"{h}.elev")
 
 
-def get_tile_elevation(obj, progress_cb=None):
+def compute_and_store_tile_bounds(obj):
+    """Compute geographic bounds from obj's mesh and write them to tp3d.
 
-    mesh = obj.data
-    api = bpy.context.scene.tp3d.api
-
+    Returns (world_verts, num_subdivisions, disable_cache, minLat, maxLat, minLon, maxLon).
+    """
     from .geo import convert_to_geo, haversine  # deferred to avoid circular import at load time
 
-    # Set chunk size based on API
-    if api == "OPENTOPODATA" or api == "OPEN-ELEVATION":
-        chunk_size = 100000
-    elif api == "TERRAIN-TILES" or api == "OPENTOPOGRAPHY":
-        chunk_size = 50000000   # single request for all verts
-    else:
-        chunk_size = 100000  # fallback
-
+    mesh = obj.data
     vertices = list(mesh.vertices)
     obj_matrix = obj.matrix_world
 
-    # Convert all vertex positions to world space
     world_verts = [obj_matrix @ v.co for v in vertices]
 
-    # Get min/max bounds in world space
     min_x = min(v.x for v in world_verts)
     max_x = max(v.x for v in world_verts)
     min_y = min(v.y for v in world_verts)
@@ -664,14 +655,34 @@ def get_tile_elevation(obj, progress_cb=None):
     num_subdivisions = bpy.context.scene.tp3d.num_subdivisions
     disable_cache = bpy.context.scene.tp3d.disableCache
 
-    realdist1 = haversine(minLat,minLon,maxLat,maxLon)*1
-    realdist2 = haversine(minLat,minLon,maxLat,maxLon)*1
+    realdist1 = haversine(minLat, minLon, maxLat, maxLon)
+    realdist2 = haversine(minLat, minLon, maxLat, maxLon)
 
-    bpy.context.scene.tp3d["sMapInKm"] = max(realdist1,realdist2)
-    bpy.context.scene.tp3d["minLat"] = minLat
+    bpy.context.scene.tp3d["sMapInKm"] = max(realdist1, realdist2)
+    bpy.context.scene.tp3d.minLat = minLat
     bpy.context.scene.tp3d.maxLat = maxLat
     bpy.context.scene.tp3d.minLon = minLon
     bpy.context.scene.tp3d.maxLon = maxLon
+
+    return world_verts, num_subdivisions, disable_cache, minLat, maxLat, minLon, maxLon
+
+
+def get_tile_elevation(obj, progress_cb=None):
+
+    mesh = obj.data
+    api = bpy.context.scene.tp3d.api
+
+    from .geo import convert_to_geo  # deferred to avoid circular import at load time
+
+    # Set chunk size based on API
+    if api == "OPENTOPODATA" or api == "OPEN-ELEVATION":
+        chunk_size = 100000
+    elif api == "TERRAIN-TILES" or api == "OPENTOPOGRAPHY":
+        chunk_size = 50000000   # single request for all verts
+    else:
+        chunk_size = 100000  # fallback
+
+    world_verts, num_subdivisions, disable_cache, minLat, maxLat, minLon, maxLon = compute_and_store_tile_bounds(obj)
 
     # ── Elevation results cache ───────────────────────────────────────────────
     # Key on geographic bounds + API + subdivision count so the same map on
@@ -706,13 +717,13 @@ def get_tile_elevation(obj, progress_cb=None):
 
         coords = [convert_to_geo(v.x, v.y) for v in chunk]
         if api == "OPENTOPODATA":
-            chunk_elevations = get_elevation_openTopoData(coords, len(vertices), i, progress_cb=progress_cb)
+            chunk_elevations = get_elevation_openTopoData(coords, len(world_verts), i, progress_cb=progress_cb)
         elif api == "OPEN-ELEVATION":
-            chunk_elevations = get_elevation_openElevation(coords, len(vertices), i, progress_cb=progress_cb)
+            chunk_elevations = get_elevation_openElevation(coords, len(world_verts), i, progress_cb=progress_cb)
         elif api == "TERRAIN-TILES":
-            chunk_elevations = get_elevation_TerrainTiles(coords, len(vertices), i, progress_cb=progress_cb)
+            chunk_elevations = get_elevation_TerrainTiles(coords, len(world_verts), i, progress_cb=progress_cb)
         elif api == "OPENTOPOGRAPHY":
-            chunk_elevations = get_elevation_openTopography(coords, len(vertices), i, progress_cb=progress_cb)
+            chunk_elevations = get_elevation_openTopography(coords, len(world_verts), i, progress_cb=progress_cb)
         else:
             chunk_elevations = [0.0] * len(chunk)  # fallback
 

--- a/TrailPrint3D/utils/elevation.py
+++ b/TrailPrint3D/utils/elevation.py
@@ -618,6 +618,14 @@ def get_elevation_path_openTopoData(vertices):
     return coords
 
 
+def _elevation_results_key(minLat, maxLat, minLon, maxLon, api, num_subdivisions):
+    """Return the cache file path for a given map configuration."""
+    import hashlib
+    raw = f"{minLat:.6f},{maxLat:.6f},{minLon:.6f},{maxLon:.6f},{api},{num_subdivisions}"
+    h = hashlib.md5(raw.encode()).hexdigest()
+    return os.path.join(const.elevation_results_dir, f"{h}.elev")
+
+
 def get_tile_elevation(obj, progress_cb=None):
 
     mesh = obj.data
@@ -653,6 +661,8 @@ def get_tile_elevation(obj, progress_cb=None):
     minLon = minl[1]
     maxLon = maxl[1]
 
+    num_subdivisions = bpy.context.scene.tp3d.num_subdivisions
+    disable_cache = bpy.context.scene.tp3d.disableCache
 
     realdist1 = haversine(minLat,minLon,maxLat,maxLon)*1
     realdist2 = haversine(minLat,minLon,maxLat,maxLon)*1
@@ -663,6 +673,32 @@ def get_tile_elevation(obj, progress_cb=None):
     bpy.context.scene.tp3d.minLon = minLon
     bpy.context.scene.tp3d.maxLon = maxLon
 
+    # ── Elevation results cache ───────────────────────────────────────────────
+    # Key on geographic bounds + API + subdivision count so the same map on
+    # re-generation skips all tile fetching / PNG parsing.
+    _cache_path = _elevation_results_key(minLat, maxLat, minLon, maxLon, api, num_subdivisions)
+    if not disable_cache and os.path.exists(_cache_path):
+        try:
+            with open(_cache_path, "rb") as _f:
+                _raw = zlib.decompress(_f.read())
+            _n = struct.unpack_from("<I", _raw, 0)[0]
+            elevations = list(struct.unpack_from(f"<{_n}f", _raw, 4))
+            if len(elevations) == len(world_verts):
+                print(f"Elevation cache hit ({_n} verts) — skipping API fetch")
+                lowestElevation = min(elevations)
+                highestElevation = max(elevations)
+                additionalExtrusion = lowestElevation
+                diff = highestElevation - lowestElevation
+                bpy.context.scene.tp3d["o_verticesMap"] = str(len(mesh.vertices))
+                bpy.context.scene.tp3d.lowestElevation = lowestElevation
+                bpy.context.scene.tp3d.highestElevation = highestElevation
+                bpy.context.scene.tp3d.sAdditionalExtrusion = additionalExtrusion
+                return elevations, diff
+            else:
+                print(f"Elevation cache vertex count mismatch ({len(elevations)} vs {len(world_verts)}) — refetching")
+        except Exception as _e:
+            print(f"Elevation cache read error: {_e} — refetching")
+    # ─────────────────────────────────────────────────────────────────────────
 
     elevations = []
     for i in range(0, len(world_verts), chunk_size):
@@ -686,6 +722,16 @@ def get_tile_elevation(obj, progress_cb=None):
         del chunk_elevations
 
     save_elevation_cache()
+
+    # Save results cache for future re-generations of the same map.
+    try:
+        os.makedirs(const.elevation_results_dir, exist_ok=True)
+        _n = len(elevations)
+        _packed = struct.pack("<I", _n) + struct.pack(f"<{_n}f", *elevations)
+        with open(_cache_path, "wb") as _f:
+            _f.write(zlib.compress(_packed, level=1))
+    except Exception as _e:
+        print(f"Elevation cache write error: {_e}")
 
     lowestElevation = min(elevations)
     highestElevation = max(elevations)

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -410,6 +410,22 @@ def _rg_start_osm_prefetch(tp3d, map_km):
         _active_kind_tasks.append(("BUILDINGS", _tile_tasks))
     if any([tp3d.el_sBigActive, tp3d.el_sMedActive, tp3d.el_sSmallActive]) and map_km <= const.ROADS_MAXSIZE:
         _active_kind_tasks.append(("STREETS", _tile_tasks))
+    # Ocean/coastline uses a padded bbox (+10%) to ensure coastline curves extend
+    # past the map edges for correct boolean clipping.  Pre-fetch it now with that
+    # same bbox so fetch_osm_data hits the cache when createOcean runs later.
+    if tp3d.el_oActive == 1:
+        _ocean_pad_lat = (tp3d.maxLat - tp3d.minLat) * 0.10
+        _ocean_lon_span = tp3d.maxLon - tp3d.minLon
+        if _ocean_lon_span < 0:
+            _ocean_lon_span += 360
+        _ocean_pad_lon = _ocean_lon_span * 0.10
+        _ocean_bbox = (
+            tp3d.minLat - _ocean_pad_lat,
+            max(-180.0, tp3d.minLon - _ocean_pad_lon),
+            tp3d.maxLat + _ocean_pad_lat,
+            min(180.0,  tp3d.maxLon + _ocean_pad_lon),
+        )
+        _active_kind_tasks.append(("COASTLINE", [_ocean_bbox]))
     if not _active_kind_tasks:
         return None, {}
 

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -11,6 +11,7 @@ from bpy.app.translations import pgettext as _
 from .. import progress as _progress
 from .. import addon_preferences
 from .. import constants as const
+from .elevation import compute_and_store_tile_bounds
 
 
 # ---------------------------------------------------------------------------
@@ -1055,6 +1056,8 @@ def runGeneration(type, locked_scale=None):
     # Swap in trail_map GPX coordinates after the shape is positioned
     if "trail_map" in flags:
         coordinates = coordinates2
+
+    compute_and_store_tile_bounds(MapObject)
 
     _map_km = round(bpy.context.scene.tp3d.get("sMapInKm", 0), 1)
     overlay.add_completed_step(f"Map shape created  ({props['shape'].capitalize()}, {_map_km} km)")

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -345,12 +345,90 @@ def _rg_create_map_object(flags, props, modelname, centerx, centery):
     return MapObject
 
 
-def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, phase_end=0.95):
+# ---------------------------------------------------------------------------
+# Coloring-element definitions — used by both the OSM prefetch helper and the
+# main terrain-element builder.  Tuple layout:
+#   (result_key, active_flag_attr, max_size_const, phase_label, fetch_message)
+# ---------------------------------------------------------------------------
+COLORING_ELEMENTS = [
+    ('forest',  'col_fActive',   const.FOREST_MAXSIZE,  "Forest",  "Fetching forest data\u2026"),
+    ('water',   lambda t: t.col_wPondsActive or t.col_wSmallRiversActive or t.col_wBigRiversActive, const.WATER_MAXSIZE, "Water", "Fetching water data\u2026"),
+    ('scree',   'col_scrActive', const.SCREE_MAXSIZE,   "Scree",   "Fetching scree data\u2026"),
+    ('city',       'col_cActive',   const.CITY_MAXSIZE,       "City",       "Fetching city data\u2026"),
+    ('greenspace', 'col_grActive', const.GREENSPACE_MAXSIZE, "Greenspace", "Fetching greenspace data\u2026"),
+    ('farmland',   'col_faActive', const.FARMLAND_MAXSIZE,   "Farmland",   "Fetching farmland data\u2026"),
+    ('glacier',  'col_glActive',  const.GLACIER_MAXSIZE,  "Glacier",  "Fetching glacier data\u2026"),
+]
+
+
+def _rg_start_osm_prefetch(tp3d, map_km):
+    """Snapshot all bpy values on the main thread and launch a daemon thread
+    that pre-fetches every active OSM coloring kind before mesh-building begins.
+
+    The caller must call thread.join() before consuming the result dict.
+    Returns (None, {}) immediately if no coloring elements are active.
+    """
+    from .terrain import _fetch_all_kinds_parallel  # deferred to avoid circular import at load time
+    from .osm import OsmFetchSettings               # deferred to avoid circular import at load time
+
+    _lat_step  = min(2.0, tp3d.maxLat - tp3d.minLat)
+    _lon_step  = min(2.0, tp3d.maxLon - tp3d.minLon)
+    _tile_lats = math.ceil((tp3d.maxLat - tp3d.minLat) / _lat_step)
+    _tile_lons = math.ceil((tp3d.maxLon - tp3d.minLon) / _lon_step)
+    _tile_tasks = [
+        (tp3d.minLat + k * _lat_step,
+         tp3d.minLon + l * _lon_step,
+         tp3d.minLat + k * _lat_step + _lat_step,
+         tp3d.minLon + l * _lon_step + _lon_step)
+        for k in range(_tile_lats)
+        for l in range(_tile_lons)
+    ]
+    _semaphore = threading.Semaphore(2)  # max 2 concurrent live Overpass requests
+    _fetch_settings = OsmFetchSettings(
+        disable_cache       = tp3d.disableCache,
+        api_retries         = tp3d.apiRetries,
+        mapsize             = tp3d.sMapInKm,
+        road_big            = bool(tp3d.el_sBigActive),
+        road_med            = bool(tp3d.el_sMedActive),
+        road_small          = bool(tp3d.el_sSmallActive),
+        water_ponds         = bool(tp3d.col_wPondsActive),
+        water_small_rivers  = bool(tp3d.col_wSmallRiversActive),
+        water_big_rivers    = bool(tp3d.col_wBigRiversActive),
+    )
+    _active_kind_tasks = [
+        (key.upper(), _tile_tasks)
+        for key, flag_attr, max_size, _, _ in COLORING_ELEMENTS
+        if (flag_attr(tp3d) if callable(flag_attr) else getattr(tp3d, flag_attr) == 1)
+        and map_km <= max_size
+    ]
+    if tp3d.el_bActive == 1 and map_km <= const.BUILDINGS_MAXSIZE:
+        _active_kind_tasks.append(("BUILDINGS", _tile_tasks))
+    if any([tp3d.el_sBigActive, tp3d.el_sMedActive, tp3d.el_sSmallActive]) and map_km <= const.ROADS_MAXSIZE:
+        _active_kind_tasks.append(("STREETS", _tile_tasks))
+    if not _active_kind_tasks:
+        return None, {}
+
+    result = {}
+
+    def _run():
+        fetched = _fetch_all_kinds_parallel(_active_kind_tasks, _semaphore,
+                                            settings=_fetch_settings)
+        result.update(fetched)
+
+    t = threading.Thread(target=_run, daemon=True, name="osm-prefetch")
+    t.start()
+    return t, result
+
+
+def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, phase_end=0.95,
+                               prefetched_osm=None):
     """Create water, forest, city, glacier, building and road overlay meshes.
 
     Reads all flags directly from bpy.context.scene.tp3d.
     Returns a dict keyed by element name; values may be None if disabled.
     phase_start/phase_end control the overlay progress range for multi-tile callers.
+    prefetched_osm: result dict from _rg_start_osm_prefetch; if provided the
+    per-kind OSM fetch is skipped (data was already downloaded in the background).
     """
     from .terrain import coloring_main, createOcean, _COLORING_EMPTY, _COLORING_PAINTED, _fetch_all_kinds_parallel  # deferred to avoid circular import at load time
     from .osm import OsmFetchSettings  # deferred to avoid circular import at load time
@@ -405,51 +483,44 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
     _water_ocean_combined = _water_feat_active and _ocean_active
 
     # --------------------------------------------------
-    # Pre-compute tile bboxes (shared across all active coloring kinds).
-    # These are fetched in parallel before mesh-building to hide network latency.
+    # Fetch all active OSM kinds unless already done by the background thread
+    # started before elevation (prefetched_osm != None means data is ready).
     # --------------------------------------------------
-    _lat_step = min(2.0, tp3d.maxLat - tp3d.minLat)
-    _lon_step = min(2.0, tp3d.maxLon - tp3d.minLon)
-    _tile_lats = math.ceil((tp3d.maxLat - tp3d.minLat) / _lat_step)
-    _tile_lons = math.ceil((tp3d.maxLon - tp3d.minLon) / _lon_step)
-    _tile_tasks = [
-        (tp3d.minLat + k * _lat_step,
-         tp3d.minLon + l * _lon_step,
-         tp3d.minLat + k * _lat_step + _lat_step,
-         tp3d.minLon + l * _lon_step + _lon_step)
-        for k in range(_tile_lats)
-        for l in range(_tile_lons)
-    ]
-    _overpass_semaphore = threading.Semaphore(2)  # max 2 concurrent live Overpass requests
-
-    # Snapshot all bpy.context values needed by fetch_osm_data on the main
-    # thread NOW, before any worker threads are spawned.  Workers receive this
-    # plain namedtuple so they never touch bpy.context.
-    _fetch_settings = OsmFetchSettings(
-        disable_cache       = tp3d.disableCache,
-        api_retries         = tp3d.apiRetries,
-        mapsize             = tp3d.sMapInKm,
-        road_big            = bool(tp3d.el_sBigActive),
-        road_med            = bool(tp3d.el_sMedActive),
-        road_small          = bool(tp3d.el_sSmallActive),
-        water_ponds         = bool(tp3d.col_wPondsActive),
-        water_small_rivers  = bool(tp3d.col_wSmallRiversActive),
-        water_big_rivers    = bool(tp3d.col_wBigRiversActive),
-    )
-
-    # --------------------------------------------------
-    # Pre-fetch ALL active kinds × all tiles simultaneously.
-    # All HTTP round-trips overlap; the semaphore caps live requests to 2 at
-    # a time.  Processing (bpy.*) still runs sequentially on the main thread.
-    # --------------------------------------------------
-    _active_kind_tasks = [
-        (key.upper(), _tile_tasks)
-        for key, flag_attr, max_size, _, _ in COLORING_ELEMENTS
-        if (flag_attr(tp3d) if callable(flag_attr) else getattr(tp3d, flag_attr) == 1)
-        and map_km <= max_size
-    ]
-    _all_prefetched = _fetch_all_kinds_parallel(_active_kind_tasks, _overpass_semaphore,
-                                                settings=_fetch_settings)
+    if prefetched_osm is None:
+        _lat_step = min(2.0, tp3d.maxLat - tp3d.minLat)
+        _lon_step = min(2.0, tp3d.maxLon - tp3d.minLon)
+        _tile_lats = math.ceil((tp3d.maxLat - tp3d.minLat) / _lat_step)
+        _tile_lons = math.ceil((tp3d.maxLon - tp3d.minLon) / _lon_step)
+        _tile_tasks = [
+            (tp3d.minLat + k * _lat_step,
+             tp3d.minLon + l * _lon_step,
+             tp3d.minLat + k * _lat_step + _lat_step,
+             tp3d.minLon + l * _lon_step + _lon_step)
+            for k in range(_tile_lats)
+            for l in range(_tile_lons)
+        ]
+        _overpass_semaphore = threading.Semaphore(2)  # max 2 concurrent live Overpass requests
+        _fetch_settings = OsmFetchSettings(
+            disable_cache       = tp3d.disableCache,
+            api_retries         = tp3d.apiRetries,
+            mapsize             = tp3d.sMapInKm,
+            road_big            = bool(tp3d.el_sBigActive),
+            road_med            = bool(tp3d.el_sMedActive),
+            road_small          = bool(tp3d.el_sSmallActive),
+            water_ponds         = bool(tp3d.col_wPondsActive),
+            water_small_rivers  = bool(tp3d.col_wSmallRiversActive),
+            water_big_rivers    = bool(tp3d.col_wBigRiversActive),
+        )
+        _active_kind_tasks = [
+            (key.upper(), _tile_tasks)
+            for key, flag_attr, max_size, _, _ in COLORING_ELEMENTS
+            if (flag_attr(tp3d) if callable(flag_attr) else getattr(tp3d, flag_attr) == 1)
+            and map_km <= max_size
+        ]
+        _all_prefetched = _fetch_all_kinds_parallel(_active_kind_tasks, _overpass_semaphore,
+                                                    settings=_fetch_settings)
+    else:
+        _all_prefetched = prefetched_osm
 
     terrain = {}
     for key, flag_attr, max_size, phase, msg in COLORING_ELEMENTS:
@@ -991,6 +1062,12 @@ def runGeneration(type, locked_scale=None):
     # Build the fetch-item strip
     overlay.set_fetch_items(build_fetch_items(_map_km))
 
+    # --- OSM background prefetch: start now so Overpass requests overlap with elevation download ---
+    _tp3d_snap = bpy.context.scene.tp3d
+    _osm_prefetch_thread, _osm_prefetched = _rg_start_osm_prefetch(_tp3d_snap, _map_km)
+    if _osm_prefetch_thread is not None:
+        print("OSM prefetch started (overlapping elevation download)")
+
     # --- Phase 9: Fetch terrain elevation data ---
     overlay.update(0.38, "Fetching Elevation Data", "Querying API — this may take a moment…")
     print("------------------------------------------------")
@@ -1272,7 +1349,10 @@ def runGeneration(type, locked_scale=None):
 
     # --- Phase 14: Create terrain overlay elements ---
     overlay.update(0.83, "Terrain Elements", "Adding elements…")
-    elements = _rg_build_terrain_elements(obj, scaleHor, curveObj=curveObjs[0] if curveObjs else None)
+    if _osm_prefetch_thread is not None:
+        _osm_prefetch_thread.join()
+    elements = _rg_build_terrain_elements(obj, scaleHor, curveObj=curveObjs[0] if curveObjs else None,
+                                          prefetched_osm=_osm_prefetched)
 
     # --- Phase 15: Single color mode processing ---
     overlay.update(0.95, "Coloring", "Applying single-color mode…")

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -4,6 +4,7 @@ import time
 import os
 import platform
 import random
+import threading
 import numpy as np
 from mathutils import Vector  # type: ignore
 from bpy.app.translations import pgettext as _
@@ -300,6 +301,8 @@ def _rg_create_map_object(flags, props, modelname, centerx, centery):
     yTerrainOffset = props['yTerrainOffset']
 
     if "append_collection" not in flags and "use_active_object" not in flags:
+        print(f"[map_object] creating '{shape}' N={num_subdivisions} size={size:.1f}…")
+        _t_shape = time.time()
         if shape == "SQUARE":
             rHeight = bpy.context.scene.tp3d.rectangleHeight
             MapObject = create_rectangle(size, rHeight, num_subdivisions, modelname)
@@ -316,6 +319,7 @@ def _rg_create_map_object(flags, props, modelname, centerx, centery):
             MapObject = create_ellipse(size / 2, num_subdivisions, modelname, ratio)
         else:
             MapObject = create_hexagon(size / 2, num_subdivisions, modelname)
+        print(f"[map_object] shape created in {time.time()-_t_shape:.3f}s")
     if "append_collection" in flags:
         appendCollection()
         MapObject = bpy.context.view_layer.objects.active
@@ -348,7 +352,7 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
     Returns a dict keyed by element name; values may be None if disabled.
     phase_start/phase_end control the overlay progress range for multi-tile callers.
     """
-    from .terrain import coloring_main, createOcean, _COLORING_EMPTY, _COLORING_PAINTED  # deferred to avoid circular import at load time
+    from .terrain import coloring_main, createOcean, _COLORING_EMPTY, _COLORING_PAINTED, _fetch_all_kinds_parallel  # deferred to avoid circular import at load time
     from .osm import create_buildings, create_roads  # deferred to avoid circular import at load time
     from .scene import set_origin_to_3d_cursor, get_random_world_vertices  # deferred to avoid circular import at load time
     from .mesh_ops import intersectWithTile  # deferred to avoid circular import at load time
@@ -399,6 +403,37 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
     _ocean_active = tp3d.el_oActive == 1
     _water_ocean_combined = _water_feat_active and _ocean_active
 
+    # --------------------------------------------------
+    # Pre-compute tile bboxes (shared across all active coloring kinds).
+    # These are fetched in parallel before mesh-building to hide network latency.
+    # --------------------------------------------------
+    _lat_step = min(2.0, tp3d.maxLat - tp3d.minLat)
+    _lon_step = min(2.0, tp3d.maxLon - tp3d.minLon)
+    _tile_lats = math.ceil((tp3d.maxLat - tp3d.minLat) / _lat_step)
+    _tile_lons = math.ceil((tp3d.maxLon - tp3d.minLon) / _lon_step)
+    _tile_tasks = [
+        (tp3d.minLat + k * _lat_step,
+         tp3d.minLon + l * _lon_step,
+         tp3d.minLat + k * _lat_step + _lat_step,
+         tp3d.minLon + l * _lon_step + _lon_step)
+        for k in range(_tile_lats)
+        for l in range(_tile_lons)
+    ]
+    _overpass_semaphore = threading.Semaphore(2)  # max 2 concurrent live Overpass requests
+
+    # --------------------------------------------------
+    # Pre-fetch ALL active kinds × all tiles simultaneously.
+    # All HTTP round-trips overlap; the semaphore caps live requests to 2 at
+    # a time.  Processing (bpy.*) still runs sequentially on the main thread.
+    # --------------------------------------------------
+    _active_kind_tasks = [
+        (key.upper(), _tile_tasks)
+        for key, flag_attr, max_size, _, _ in COLORING_ELEMENTS
+        if (flag_attr(tp3d) if callable(flag_attr) else getattr(tp3d, flag_attr) == 1)
+        and map_km <= max_size
+    ]
+    _all_prefetched = _fetch_all_kinds_parallel(_active_kind_tasks, _overpass_semaphore)
+
     terrain = {}
     for key, flag_attr, max_size, phase, msg in COLORING_ELEMENTS:
         terrain[key] = None
@@ -406,7 +441,7 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
             if map_km <= max_size:
                 _advance_elem_progress(phase, msg)
                 _ov.set_fetch_progress(key, 0.0)
-                _result = coloring_main(obj, key.upper())
+                _result = coloring_main(obj, key.upper(), prefetched_tiles=_all_prefetched.get(key.upper(), {}))
                 if _result is _COLORING_EMPTY:
                     terrain[key] = None
                     _ov.set_fetch_empty(key)
@@ -1169,7 +1204,6 @@ def runGeneration(type, locked_scale=None):
     bpy.ops.object.select_all(action='DESELECT')
 
     if "append_collection" not in flags:
-        print("Chicken")
         if shape == "HEXAGON INNER TEXT":
             textobj = HexagonInnerText(MapObject)
         elif shape == "HEXAGON OUTER TEXT":

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -372,10 +372,14 @@ def _rg_start_osm_prefetch(tp3d, map_km):
     from .terrain import _fetch_all_kinds_parallel  # deferred to avoid circular import at load time
     from .osm import OsmFetchSettings               # deferred to avoid circular import at load time
 
-    _lat_step  = min(2.0, tp3d.maxLat - tp3d.minLat)
-    _lon_step  = min(2.0, tp3d.maxLon - tp3d.minLon)
-    _tile_lats = math.ceil((tp3d.maxLat - tp3d.minLat) / _lat_step)
-    _tile_lons = math.ceil((tp3d.maxLon - tp3d.minLon) / _lon_step)
+    _lat_span  = tp3d.maxLat - tp3d.minLat
+    _lon_span  = tp3d.maxLon - tp3d.minLon
+    if _lat_span <= 0 or _lon_span <= 0:
+        return None, {}
+    _lat_step  = min(2.0, _lat_span)
+    _lon_step  = min(2.0, _lon_span)
+    _tile_lats = math.ceil(_lat_span / _lat_step)
+    _tile_lons = math.ceil(_lon_span / _lon_step)
     _tile_tasks = [
         (tp3d.minLat + k * _lat_step,
          tp3d.minLon + l * _lon_step,

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -353,6 +353,7 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
     phase_start/phase_end control the overlay progress range for multi-tile callers.
     """
     from .terrain import coloring_main, createOcean, _COLORING_EMPTY, _COLORING_PAINTED, _fetch_all_kinds_parallel  # deferred to avoid circular import at load time
+    from .osm import OsmFetchSettings  # deferred to avoid circular import at load time
     from .osm import create_buildings, create_roads  # deferred to avoid circular import at load time
     from .scene import set_origin_to_3d_cursor, get_random_world_vertices  # deferred to avoid circular import at load time
     from .mesh_ops import intersectWithTile  # deferred to avoid circular import at load time
@@ -421,6 +422,21 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
     ]
     _overpass_semaphore = threading.Semaphore(2)  # max 2 concurrent live Overpass requests
 
+    # Snapshot all bpy.context values needed by fetch_osm_data on the main
+    # thread NOW, before any worker threads are spawned.  Workers receive this
+    # plain namedtuple so they never touch bpy.context.
+    _fetch_settings = OsmFetchSettings(
+        disable_cache       = tp3d.disableCache,
+        api_retries         = tp3d.apiRetries,
+        mapsize             = tp3d.sMapInKm,
+        road_big            = bool(tp3d.el_sBigActive),
+        road_med            = bool(tp3d.el_sMedActive),
+        road_small          = bool(tp3d.el_sSmallActive),
+        water_ponds         = bool(tp3d.col_wPondsActive),
+        water_small_rivers  = bool(tp3d.col_wSmallRiversActive),
+        water_big_rivers    = bool(tp3d.col_wBigRiversActive),
+    )
+
     # --------------------------------------------------
     # Pre-fetch ALL active kinds × all tiles simultaneously.
     # All HTTP round-trips overlap; the semaphore caps live requests to 2 at
@@ -432,7 +448,8 @@ def _rg_build_terrain_elements(obj, scaleHor, curveObj=None, phase_start=0.83, p
         if (flag_attr(tp3d) if callable(flag_attr) else getattr(tp3d, flag_attr) == 1)
         and map_km <= max_size
     ]
-    _all_prefetched = _fetch_all_kinds_parallel(_active_kind_tasks, _overpass_semaphore)
+    _all_prefetched = _fetch_all_kinds_parallel(_active_kind_tasks, _overpass_semaphore,
+                                                settings=_fetch_settings)
 
     terrain = {}
     for key, flag_attr, max_size, phase, msg in COLORING_ELEMENTS:

--- a/TrailPrint3D/utils/geo.py
+++ b/TrailPrint3D/utils/geo.py
@@ -183,8 +183,6 @@ def calculate_date(points):
     if len(points) < 2:
         return ""
     st = points[0][3]
-    print(st)
-    print(type(st))
 
     if st:
         dt = str(st.date())

--- a/TrailPrint3D/utils/mesh_ops.py
+++ b/TrailPrint3D/utils/mesh_ops.py
@@ -195,13 +195,16 @@ def merge_objects(objects, name="MergedObject"):
     Simple UI-style merge: select objects, make the first one active, and call join.
     This is fast but requires changing selection/context.
     """
-
-    print("This one")
     # filter only mesh objects
     #mesh_objs = [o for o in objects if o.type == 'MESH']
     mesh_objs = objects
     if not mesh_objs:
         return None
+    if len(mesh_objs) == 1:
+        bpy.ops.object.select_all(action='DESELECT')
+        mesh_objs[0].select_set(True)
+        bpy.context.view_layer.objects.active = mesh_objs[0]
+        return mesh_objs[0]
 
 
     # ensure in same collection / visible

--- a/TrailPrint3D/utils/mesh_ops.py
+++ b/TrailPrint3D/utils/mesh_ops.py
@@ -1266,19 +1266,19 @@ def remeshClearing(obj, voxelSize2, tolerance):
     for v in bm2.verts:
         v.select = abs(v.co.z - top_z) > 0.001
     bmesh.update_edit_mesh(obj.data)
+    # Drop the stale reference BEFORE the operator modifies the mesh.
+    # Keeping bm2 alive past mesh.delete causes a dangling C pointer:
+    # on the second generation Blender reuses that freed memory and
+    # python313.dll crashes when mode_set later finalises the edit mesh.
+    del bm2
     bpy.ops.mesh.delete(type='VERT')
-    #bpy.ops.object.mode_set(mode='OBJECT')
-    #----------------
-    #bpy.ops.mesh.delete(type='VERT')
-
 
     # Flatten remaining verts to exactly z bottom_z
     bm = bmesh.from_edit_mesh(obj.data)
     for v in bm.verts:
         v.co.z = bottom_z
     bmesh.update_edit_mesh(obj.data)
-
-
+    del bm  # discard before exiting edit mode to avoid the same issue
 
     # Extrude upward by 30
     bpy.ops.mesh.select_mode(type='FACE')

--- a/TrailPrint3D/utils/osm.py
+++ b/TrailPrint3D/utils/osm.py
@@ -12,6 +12,66 @@ from .. import constants as const
 from .. import progress as _progress
 
 
+def _overpass_request(query, overpass_url, method='POST', timeout=60, max_retries=3,
+                      log_callback=None):
+    """Make one Overpass API request with retry/backoff.
+
+    Parameters
+    ----------
+    query        : Overpass QL string
+    overpass_url : endpoint URL
+    method       : 'POST' (default) or 'GET'
+    timeout      : per-request timeout in seconds
+    max_retries  : total attempts before giving up
+    log_callback : optional callable(str) for progress messages — called from
+                   whatever thread this runs on, so keep it thread-safe.
+
+    Returns the parsed JSON dict on success, or None on failure.
+    """
+    for attempt in range(max_retries):
+        try:
+            if method == 'POST':
+                response = requests.post(
+                    overpass_url,
+                    data={"data": query},
+                    headers={'User-Agent': 'TrailPrint3D_3.00', 'Accept': '*/*'},
+                    timeout=timeout,
+                )
+            else:
+                response = requests.get(
+                    overpass_url,
+                    params={'data': query},
+                    headers={'User-Agent': 'TrailPrint3D_3.00', 'Accept': '*/*'},
+                    timeout=timeout,
+                )
+
+            if response.status_code == 200:
+                try:
+                    return response.json()
+                except ValueError:
+                    print(f"Attempt {attempt + 1}: Invalid JSON response")
+                    # fall through to retry
+            else:
+                retry_num = attempt + 2
+                print(f"Status ({response.status_code}), retrying... {retry_num}/{max_retries}")
+                if log_callback:
+                    log_callback(f"Overpass error {response.status_code} — retrying {retry_num}/{max_retries}")
+                time.sleep(5 + attempt)
+
+        except requests.exceptions.Timeout:
+            retry_num = attempt + 2
+            print(f"Request timed out (attempt {attempt + 1}/{max_retries})")
+            if log_callback:
+                log_callback(f"Timed out — retrying {retry_num}/{max_retries}")
+            time.sleep(5)
+        except requests.RequestException as e:
+            print(f"Request failed: {e}")
+            time.sleep(5)
+
+    print("Overpass request failed after retries")
+    return None
+
+
 def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_status=False):
     #print("FETCH OSM:", kind)
 
@@ -200,49 +260,25 @@ def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_sta
     # --------------------------------------------------
     # Request with retries
     # --------------------------------------------------
-    for attempt in range(apiRetries):
-        try:
-            response = requests.post(
-                overpass_url,
-                data={"data": query},
-                headers={'User-Agent': 'TrailPrint3D_3.00', 'Accept': '*/*'},
-                timeout=60
-            )
-            print(query)
+    def _log(msg):
+        _ov = _progress.ProgressOverlay.get()
+        if _ov.active:
+            _ov.update(message=msg)
 
-            if response.status_code == 200:
-                data = response.json()
+    print(query)
+    data = _overpass_request(
+        query, overpass_url,
+        method='POST', timeout=60, max_retries=apiRetries,
+        log_callback=_log,
+    )
+    if data is None:
+        _progress.WarningsOverlay.add_warning(f"failed to fetch {kind} elements from Overpass API", "error")
+        return None
 
-                # --------------------------------------------------
-                # Write cache
-                # --------------------------------------------------
-                with open(cache_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f)
+    with open(cache_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
 
-                return (data, False) if return_cache_status else data
-
-            elif response.status_code != 200:
-                retry_num = attempt + 2
-                print(f"Status ({response.status_code}), retrying... {retry_num}/{apiRetries}")
-                _ov = _progress.ProgressOverlay.get()
-                if _ov.active:
-                    _ov.update(message=f"Overpass error — retrying {retry_num}/{apiRetries}")
-                time.sleep(5 + attempt)
-
-        except requests.exceptions.Timeout:
-            retry_num = attempt + 2
-            print(f"Request timed out (attempt {attempt + 1}/{apiRetries})")
-            _ov = _progress.ProgressOverlay.get()
-            if _ov.active:
-                _ov.update(message=f"Timed out — retrying {retry_num}/{apiRetries}")
-            time.sleep(5)
-        except Exception as e:
-            print("Request failed:", e)
-            time.sleep(5)
-
-    print("Overpass request failed after retries")
-    _progress.WarningsOverlay.add_warning(f"failed to fetch {kind} elements from Overpass API", "error")
-    return None
+    return (data, False) if return_cache_status else data
 
 
 def extract_multipolygon_bodies(elements, nodes):
@@ -370,34 +406,13 @@ def get_building_data(bbox, max_retries=5, timeout=90):
     out skel qt;
     """
 
-    for attempt in range(1, max_retries + 1):
-        try:
-            response = requests.get(overpass_url, params={'data': query}, headers={'User-Agent': 'TrailPrint3D_3.00', 'Accept': '*/*'}, timeout=timeout)
-
-
-            if response.status_code != 200:
-
-                print(f"Status ({response.status_code}), retrying... {attempt + 1}/{apiRetries}")
-            else:
-                # Try to parse JSON
-                try:
-                    data = response.json()
-                    return data  # Success
-                except ValueError:
-                    print(f"Attempt {attempt}: Invalid JSON response")
-
-        except requests.RequestException as e:
-            print(f"Attempt {attempt}: Request error: {e}")
-
-        # If not successful, wait before retrying
-        if attempt < max_retries:
-            wait_time = 2 + 1 * attempt  # exponential-ish backoff
-            print(f"Retrying in {wait_time} seconds...")
-            time.sleep(wait_time)
-
-    # If we reach here, all retries failed
-    print("Failed to fetch data from Overpass API after multiple attempts.")
-    return None
+    data = _overpass_request(
+        query, overpass_url,
+        method='GET', timeout=timeout, max_retries=max_retries,
+    )
+    if data is None:
+        print("Failed to fetch building data from Overpass API after multiple attempts.")
+    return data
 
 def create_buildings(map, default_height=10, scaleHor=1.0):
     from .geo import convert_to_blender_coordinates  # deferred to avoid circular import at load time

--- a/TrailPrint3D/utils/osm.py
+++ b/TrailPrint3D/utils/osm.py
@@ -325,6 +325,403 @@ def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_sta
     return (data, False) if return_cache_status else data
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Combined (union) fetch — one Overpass request covers all requested kinds
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_cache_path(bbox, kind, settings=None):
+    """Return the cache file path for a given bbox + kind + settings.
+
+    Mirrors the key computation inside fetch_osm_data so that
+    fetch_osm_combined writes to exactly the same files that fetch_osm_data
+    would later read, giving a warm-cache hit.
+    """
+    south, west, north, east = bbox
+    if settings is not None:
+        road_big           = settings.road_big
+        road_med           = settings.road_med
+        road_small         = settings.road_small
+        water_ponds        = settings.water_ponds
+        water_small_rivers = settings.water_small_rivers
+        water_big_rivers   = settings.water_big_rivers
+    else:
+        road_big           = bool(bpy.context.scene.tp3d.el_sBigActive)
+        road_med           = bool(bpy.context.scene.tp3d.el_sMedActive)
+        road_small         = bool(bpy.context.scene.tp3d.el_sSmallActive)
+        water_ponds        = bool(bpy.context.scene.tp3d.col_wPondsActive)
+        water_small_rivers = bool(bpy.context.scene.tp3d.col_wSmallRiversActive)
+        water_big_rivers   = bool(bpy.context.scene.tp3d.col_wBigRiversActive)
+
+    cache_kind = kind
+    if kind == "STREETS":
+        cache_kind = kind + str(road_big) + str(road_med) + str(road_small)
+    elif kind == "WATER":
+        cache_kind = kind + str(water_ponds) + str(water_small_rivers) + str(water_big_rivers)
+
+    payload = {
+        "bbox": [round(south, 7), round(west, 7), round(north, 7), round(east, 7)],
+        "kind": cache_kind,
+    }
+    key = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+    cache_dir = const.overpass_cache_dir
+    os.makedirs(cache_dir, exist_ok=True)
+    return os.path.join(cache_dir, f"{key}.json")
+
+
+def _build_union_query(south, west, north, east, kinds, settings=None):
+    """Build a single Overpass QL union query covering all requested kinds.
+
+    Returns the QL string, or None if the combination of requested kinds and
+    settings produces no filter statements (e.g. WATER requested but all
+    water sub-types are disabled).
+    """
+    if settings is not None:
+        mapsize            = settings.mapsize
+        road_big           = settings.road_big
+        road_med           = settings.road_med
+        road_small         = settings.road_small
+        water_ponds        = settings.water_ponds
+        water_small_rivers = settings.water_small_rivers
+        water_big_rivers   = settings.water_big_rivers
+    else:
+        mapsize            = bpy.context.scene.tp3d.sMapInKm
+        road_big           = bool(bpy.context.scene.tp3d.el_sBigActive)
+        road_med           = bool(bpy.context.scene.tp3d.el_sMedActive)
+        road_small         = bool(bpy.context.scene.tp3d.el_sSmallActive)
+        water_ponds        = bool(bpy.context.scene.tp3d.col_wPondsActive)
+        water_small_rivers = bool(bpy.context.scene.tp3d.col_wSmallRiversActive)
+        water_big_rivers   = bool(bpy.context.scene.tp3d.col_wBigRiversActive)
+
+    filters = []
+
+    if "FOREST" in kinds:
+        filters += [
+            'way["natural"="wood"]',
+            'relation["natural"="wood"]',
+            'way["landuse"="forest"]',
+            'relation["landuse"="forest"]',
+        ]
+
+    if "WATER" in kinds:
+        if water_ponds:
+            filters += [
+                'way["natural"="water"]',
+                'relation["natural"="water"]',
+                'way["water"~"river|lake|stream|canal"]',
+                'relation["water"~"river|lake|stream|canal"]',
+            ]
+        if water_small_rivers:
+            filters.append('way["waterway"~"stream|river|canal|ditch|drain"]')
+        elif water_big_rivers:
+            filters.append('way["waterway"~"stream|river|canal|ditch|drain"]["wikidata"]')
+
+    if "SCREE" in kinds:
+        filters += [
+            'nwr["natural"="scree"]',
+            'nwr["natural"="stone"]',
+            'nwr["natural"="boulder"]',
+            'nwr["natural"="rock"]',
+            'nwr["natural"="bare_rock"]',
+        ]
+
+    if "CITY" in kinds:
+        filters += [
+            'way["landuse"~"residential|urban|commercial|industrial"]',
+            'relation["landuse"~"residential|urban|commercial|industrial"]',
+        ]
+
+    if "GREENSPACE" in kinds:
+        filters += [
+            'way["leisure"="park"]',
+            'relation["leisure"="park"]',
+            'way["leisure"="garden"]',
+            'relation["leisure"="garden"]',
+            'way["leisure"="recreation_ground"]',
+            'relation["leisure"="recreation_ground"]',
+            'way["landuse"="grass"]',
+            'way["natural"="grass"]',
+            'way["landuse"="village_green"]',
+            'relation["landuse"="village_green"]',
+        ]
+
+    if "FARMLAND" in kinds:
+        filters += [
+            'way["landuse"="farmland"]',
+            'way["landuse"="farmyard"]',
+            'relation["landuse"="farmland"]',
+            'relation["landuse"="farmyard"]',
+        ]
+
+    if "GLACIER" in kinds:
+        filters += [
+            'way["natural"="glacier"]',
+            'relation["natural"="glacier"]',
+        ]
+
+    if "COASTLINE" in kinds:
+        filters.append('way["natural"="coastline"]')
+
+    if "BUILDINGS" in kinds:
+        filters.append('nwr["building"]')
+
+    if "STREETS" in kinds:
+        all_big   = {"primary", "motorway", "primary_link", "motorway_link"}
+        all_med   = {"secondary", "tertiary", "secondary_link", "tertiary_link",
+                     "unclassified", "trunk", "trunk_link"}
+        all_small = {"residential", "living_street", "service", "footway"}
+
+        requested: set = set()
+        if road_big:   requested |= all_big
+        if road_med:   requested |= all_med
+        if road_small: requested |= all_small
+
+        # Apply the same mapsize performance limits as _build_streets_query
+        allowed = all_big | all_med | all_small
+        if mapsize > const.ROADS_MAXSIZE:
+            allowed = all_big
+        elif mapsize > const.STREETS_PRIMARY_THRESHOLD:
+            allowed = all_big | all_med
+        elif mapsize > const.STREETS_MAJOR_ONLY_THRESHOLD:
+            allowed = all_big | all_med | all_small
+
+        highway_types = sorted(requested & allowed) or ["motorway", "primary"]
+        pattern = "|".join(highway_types)
+        filters.append(f'way["highway"~"^({pattern})$"]')
+
+    if not filters:
+        return None
+
+    filter_lines = "\n".join(f"  {f};" for f in filters)
+    return (
+        f"[out:json][timeout:120][bbox:{south},{west},{north},{east}];\n"
+        f"(\n{filter_lines}\n);\n"
+        f"out body;\n>;\nout skel qt;\n"
+    )
+
+
+def _classify_element(element, active_kinds, settings=None):
+    """Classify a way or relation element into one of *active_kinds*.
+
+    Returns the kind string, or None if no kind matches.
+    Priority order mirrors tag-filter specificity (most-specific first).
+    Bare nodes carry no kind-level tags and are not classified here.
+    """
+    tags = element.get("tags", {})
+
+    # STREETS — road network is unambiguous
+    if "STREETS" in active_kinds:
+        highway = tags.get("highway", "")
+        if highway:
+            if settings is not None:
+                all_big   = {"primary", "motorway", "primary_link", "motorway_link"}
+                all_med   = {"secondary", "tertiary", "secondary_link", "tertiary_link",
+                             "unclassified", "trunk", "trunk_link"}
+                all_small = {"residential", "living_street", "service", "footway"}
+                allowed: set = set()
+                if settings.road_big:   allowed |= all_big
+                if settings.road_med:   allowed |= all_med
+                if settings.road_small: allowed |= all_small
+                # Clamp to mapsize-based performance limits (mirror _build_streets_query)
+                if settings.mapsize > const.ROADS_MAXSIZE:
+                    allowed &= all_big
+                elif settings.mapsize > const.STREETS_PRIMARY_THRESHOLD:
+                    allowed &= all_big | all_med
+                if highway in allowed:
+                    return "STREETS"
+            else:
+                return "STREETS"
+
+    # BUILDINGS — anything with a building=* tag
+    if "BUILDINGS" in active_kinds and tags.get("building"):
+        return "BUILDINGS"
+
+    # WATER — natural water bodies and waterways
+    if "WATER" in active_kinds:
+        natural  = tags.get("natural", "")
+        water    = tags.get("water", "")
+        waterway = tags.get("waterway", "")
+        if natural == "water":
+            if settings is None or settings.water_ponds:
+                return "WATER"
+        if water in {"river", "lake", "stream", "canal"}:
+            if settings is None or settings.water_ponds:
+                return "WATER"
+        if waterway in {"stream", "river", "canal", "ditch", "drain"}:
+            if settings is None or settings.water_small_rivers:
+                return "WATER"
+            elif settings is not None and settings.water_big_rivers and tags.get("wikidata"):
+                return "WATER"
+
+    # FOREST
+    if "FOREST" in active_kinds:
+        if tags.get("natural") == "wood" or tags.get("landuse") == "forest":
+            return "FOREST"
+
+    # GLACIER
+    if "GLACIER" in active_kinds and tags.get("natural") == "glacier":
+        return "GLACIER"
+
+    # SCREE
+    if "SCREE" in active_kinds:
+        if tags.get("natural") in {"scree", "stone", "boulder", "rock", "bare_rock"}:
+            return "SCREE"
+
+    # CITY — urban land use
+    if "CITY" in active_kinds:
+        if tags.get("landuse") in {"residential", "urban", "commercial", "industrial"}:
+            return "CITY"
+
+    # GREENSPACE — parks and grassy areas
+    if "GREENSPACE" in active_kinds:
+        leisure = tags.get("leisure", "")
+        landuse = tags.get("landuse", "")
+        natural = tags.get("natural", "")
+        if leisure in {"park", "garden", "recreation_ground"}:
+            return "GREENSPACE"
+        if landuse in {"grass", "village_green"}:
+            return "GREENSPACE"
+        if natural == "grass":
+            return "GREENSPACE"
+
+    # FARMLAND
+    if "FARMLAND" in active_kinds:
+        if tags.get("landuse") in {"farmland", "farmyard"}:
+            return "FARMLAND"
+
+    # COASTLINE
+    if "COASTLINE" in active_kinds and tags.get("natural") == "coastline":
+        return "COASTLINE"
+
+    return None
+
+
+def fetch_osm_combined(bbox, kinds, settings=None, semaphore=None,
+                       max_cache_age_hours=720):
+    """Fetch all requested OSM kinds for one tile bbox in a single Overpass request.
+
+    Cache is checked per-kind first.  Only cache-miss kinds are bundled into
+    the request.  After the request the response is split by kind and each
+    subset is written to the standard per-kind cache file so that any later
+    fetch_osm_data() call for the same bbox+kind gets a cache hit.
+
+    Parameters
+    ----------
+    bbox      : (south, west, north, east) tuple
+    kinds     : sequence of OSM kind strings (e.g. ['FOREST', 'WATER'])
+    settings  : OsmFetchSettings snapshot, or None to read bpy.context live
+    semaphore : optional threading.Semaphore — acquired only during the
+                network request so that cache-only calls never contend
+    max_cache_age_hours : freshness threshold for the per-kind cache files
+
+    Returns
+    -------
+    dict  {kind: (data_dict, from_cache_bool)}
+    Only kinds successfully fetched (or found in cache) are present.
+    """
+    # ── 1. Per-kind cache check (no semaphore needed) ────────────────────
+    if settings is not None:
+        disable_cache = settings.disable_cache
+        api_retries   = settings.api_retries
+    else:
+        disable_cache = bpy.context.scene.tp3d.disableCache
+        api_retries   = bpy.context.scene.tp3d.apiRetries
+
+    result: dict = {}
+    missing: list = []
+    for kind in kinds:
+        cache_path = _make_cache_path(bbox, kind, settings)
+        if not disable_cache and os.path.exists(cache_path):
+            age_hours = (time.time() - os.path.getmtime(cache_path)) / 3600
+            if age_hours < max_cache_age_hours:
+                try:
+                    with open(cache_path, "r", encoding="utf-8") as fh:
+                        data = json.load(fh)
+                    result[kind] = (data, True)
+                    continue
+                except (OSError, json.JSONDecodeError):
+                    pass  # fall through to network fetch
+        missing.append(kind)
+
+    if not missing:
+        return result
+
+    # ── 2. Build union query ──────────────────────────────────────────────
+    south, west, north, east = bbox
+    south = max(-90.0,  min(90.0,  south))
+    north = max(-90.0,  min(90.0,  north))
+    west  = max(-180.0, min(180.0, west))
+    east  = max(-180.0, min(180.0, east))
+
+    query = _build_union_query(south, west, north, east, missing, settings)
+    if query is None:
+        return result
+
+    overpass_url = "https://overpass-api.de/api/interpreter"
+    print(f"[fetch_osm_combined] requesting {missing} for bbox {(south, west, north, east)}")
+
+    # ── 3. Network request (hold semaphore only here) ─────────────────────
+    if semaphore is not None:
+        with semaphore:
+            data = _overpass_request(
+                query, overpass_url, method="POST",
+                timeout=120, max_retries=api_retries,
+            )
+    else:
+        data = _overpass_request(
+            query, overpass_url, method="POST",
+            timeout=120, max_retries=api_retries,
+        )
+
+    if data is None:
+        _progress.WarningsOverlay.add_warning(
+            f"failed to fetch {missing} elements from Overpass API", "error"
+        )
+        return result  # return whatever cache hits we already have
+
+    # ── 4. Split response elements by kind ───────────────────────────────
+    elements = data.get("elements", [])
+
+    # Index all node elements by id for O(1) lookup
+    all_nodes: dict = {
+        e["id"]: e for e in elements if e.get("type") == "node"
+    }
+
+    # First pass: classify all way/relation elements into per-kind buckets
+    per_kind: dict = {kind: {"elements": []} for kind in missing}
+    for element in elements:
+        if element.get("type") == "node":
+            continue
+        kind = _classify_element(element, missing, settings)
+        if kind is not None:
+            per_kind[kind]["elements"].append(element)
+
+    # Second pass: add only the nodes that are actually referenced by each
+    # kind's ways.  Including every node from every kind in every bucket
+    # causes e.g. STREETS to receive hundreds of thousands of CITY/BUILDINGS
+    # nodes, making build_osm_nodes and create_roads dramatically slower.
+    for kind in missing:
+        referenced_ids: set = set()
+        for el in per_kind[kind]["elements"]:
+            if el.get("type") == "way":
+                referenced_ids.update(el.get("nodes", []))
+            # relation members are ways, not raw nodes — no node ids here
+        kind_nodes = [all_nodes[nid] for nid in referenced_ids if nid in all_nodes]
+        per_kind[kind]["elements"] = kind_nodes + per_kind[kind]["elements"]
+
+    # ── 5. Write per-kind cache files and build return value ──────────────
+    for kind in missing:
+        kind_data  = per_kind[kind]
+        cache_path = _make_cache_path(bbox, kind, settings)
+        try:
+            with open(cache_path, "w", encoding="utf-8") as fh:
+                json.dump(kind_data, fh)
+        except OSError as exc:
+            print(f"[fetch_osm_combined] cache write failed for {kind}: {exc}")
+        result[kind] = (kind_data, False)
+
+    return result
+
+
 def extract_multipolygon_bodies(elements, nodes):
     # Helper to get coordinates of a way by its node ids
     def way_coords(way):

--- a/TrailPrint3D/utils/osm.py
+++ b/TrailPrint3D/utils/osm.py
@@ -7,9 +7,27 @@ import time
 import requests
 import hashlib
 from collections import deque
+from typing import NamedTuple
 from mathutils import Vector  # type: ignore
 from .. import constants as const
 from .. import progress as _progress
+
+
+class OsmFetchSettings(NamedTuple):
+    """Snapshot of all bpy.context values needed by fetch_osm_data.
+
+    Read these on the main thread before spawning worker threads so that
+    workers never touch bpy.context.
+    """
+    disable_cache: int
+    api_retries: int
+    mapsize: float
+    road_big: bool
+    road_med: bool
+    road_small: bool
+    water_ponds: bool
+    water_small_rivers: bool
+    water_big_rivers: bool
 
 
 def _overpass_request(query, overpass_url, method='POST', timeout=60, max_retries=3,
@@ -72,18 +90,39 @@ def _overpass_request(query, overpass_url, method='POST', timeout=60, max_retrie
     return None
 
 
-def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_status=False):
+def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_status=False,
+                   settings=None):
+    """Fetch (or return cached) OSM data for a bbox + kind.
+
+    Parameters
+    ----------
+    settings : OsmFetchSettings or None
+        When supplied (worker-thread path), all bpy.context reads are skipped
+        and the pre-read values are used instead.  Must be None only when
+        called from the main thread, where bpy.context is valid.
+    """
     #print("FETCH OSM:", kind)
 
-    disableCache = bpy.context.scene.tp3d.disableCache
-    apiRetries = bpy.context.scene.tp3d.apiRetries
-    mapsize = bpy.context.scene.tp3d.sMapInKm
-    road_big   = bool(bpy.context.scene.tp3d.el_sBigActive)
-    road_med   = bool(bpy.context.scene.tp3d.el_sMedActive)
-    road_small = bool(bpy.context.scene.tp3d.el_sSmallActive)
-    water_ponds       = bool(bpy.context.scene.tp3d.col_wPondsActive)
-    water_small_rivers = bool(bpy.context.scene.tp3d.col_wSmallRiversActive)
-    water_big_rivers  = bool(bpy.context.scene.tp3d.col_wBigRiversActive)
+    if settings is not None:
+        disableCache       = settings.disable_cache
+        apiRetries         = settings.api_retries
+        mapsize            = settings.mapsize
+        road_big           = settings.road_big
+        road_med           = settings.road_med
+        road_small         = settings.road_small
+        water_ponds        = settings.water_ponds
+        water_small_rivers = settings.water_small_rivers
+        water_big_rivers   = settings.water_big_rivers
+    else:
+        disableCache       = bpy.context.scene.tp3d.disableCache
+        apiRetries         = bpy.context.scene.tp3d.apiRetries
+        mapsize            = bpy.context.scene.tp3d.sMapInKm
+        road_big           = bool(bpy.context.scene.tp3d.el_sBigActive)
+        road_med           = bool(bpy.context.scene.tp3d.el_sMedActive)
+        road_small         = bool(bpy.context.scene.tp3d.el_sSmallActive)
+        water_ponds        = bool(bpy.context.scene.tp3d.col_wPondsActive)
+        water_small_rivers = bool(bpy.context.scene.tp3d.col_wSmallRiversActive)
+        water_big_rivers   = bool(bpy.context.scene.tp3d.col_wBigRiversActive)
 
     def get_cache_dir():
         path = const.overpass_cache_dir
@@ -260,12 +299,17 @@ def fetch_osm_data(bbox, kind="WATER", max_cache_age_hours=720, return_cache_sta
     # --------------------------------------------------
     # Request with retries
     # --------------------------------------------------
-    def _log(msg):
-        _ov = _progress.ProgressOverlay.get()
-        if _ov.active:
-            _ov.update(message=msg)
+    # Progress callback — only safe on the main thread (ProgressOverlay touches
+    # bpy.context.region).  Worker threads pass settings!=None so _log is None.
+    if settings is None:
+        def _log(msg):
+            _ov = _progress.ProgressOverlay.get()
+            if _ov.active:
+                _ov.update(message=msg)
+    else:
+        _log = None
 
-    print(query)
+    print(f"[fetch_osm_data] {kind}: {query.splitlines()[1].strip() if len(query.splitlines()) > 1 else query[:80]}")
     data = _overpass_request(
         query, overpass_url,
         method='POST', timeout=60, max_retries=apiRetries,
@@ -756,13 +800,6 @@ def create_roads(map, default_height=10, scaleHor=1.0, mapsize = 1):
                     # Keep same streetWidth logic as before
                     streetWidth = (width_m * 0.5) * 0.2 * scaleHor * 0.02 * streetwidthMultiplier
 
-                    print(f"Road width: {streetWidth}")
-
-                    if streetWidth <= 0.1:
-                        streetWidth *= 0.1/streetWidth
-                        any_adjusted = True
-                        print(f"Adjusted road width: {streetWidth}")
-
 
                     # Compute segment directions and per-node perpendiculars (2D perp)
                     seg_dirs = []
@@ -811,6 +848,13 @@ def create_roads(map, default_height=10, scaleHor=1.0, mapsize = 1):
                         group['faces'].append((a_left, b_left, b_right, a_right))
 
                 wm.progress_end()
+
+                # One-line width summary instead of per-road spam
+                width_summary = ", ".join(
+                    f"w{k}m={groups[k]['vert_count']//2}segs"
+                    for k in sorted(groups.keys())
+                )
+                print(f"Road widths: {width_summary}")
 
                 if _ov.active:
                     _ov.update(message=f"Roads: tile {_cntr}/{_maxcntr} — creating {n_roads} road mesh…")

--- a/TrailPrint3D/utils/osm.py
+++ b/TrailPrint3D/utils/osm.py
@@ -686,7 +686,16 @@ def fetch_osm_combined(bbox, kinds, settings=None, semaphore=None,
         e["id"]: e for e in elements if e.get("type") == "node"
     }
 
-    # First pass: classify all way/relation elements into per-kind buckets
+    # Index all way elements by id so relation member ways can be looked up
+    all_ways: dict = {
+        e["id"]: e for e in elements if e.get("type") == "way"
+    }
+
+    # First pass: classify all way/relation elements into per-kind buckets.
+    # When a relation is classified, also include its member ways — those
+    # boundary ways carry no feature tags of their own, so _classify_element
+    # returns None for them, but extract_multipolygon_bodies needs them to
+    # stitch the polygon rings.
     per_kind: dict = {kind: {"elements": []} for kind in missing}
     for element in elements:
         if element.get("type") == "node":
@@ -694,6 +703,14 @@ def fetch_osm_combined(bbox, kinds, settings=None, semaphore=None,
         kind = _classify_element(element, missing, settings)
         if kind is not None:
             per_kind[kind]["elements"].append(element)
+            if element.get("type") == "relation":
+                seen = {e["id"] for e in per_kind[kind]["elements"]}
+                for member in element.get("members", []):
+                    if member.get("type") == "way":
+                        way = all_ways.get(member["ref"])
+                        if way is not None and way["id"] not in seen:
+                            per_kind[kind]["elements"].append(way)
+                            seen.add(way["id"])
 
     # Second pass: add only the nodes that are actually referenced by each
     # kind's ways.  Including every node from every kind in every bucket

--- a/TrailPrint3D/utils/primitives.py
+++ b/TrailPrint3D/utils/primitives.py
@@ -1,6 +1,7 @@
 import bpy  # type: ignore
 import bmesh  # type: ignore
 import math
+import time
 from mathutils import Vector  # type: ignore
 
 from .text_objects import _apply_plate_bevel
@@ -119,6 +120,7 @@ def simplify_curve(points_with_extra, min_distance=0.1000):
 
 def create_hexagon(size, num_subdivisions = 1, name = "Hexagon"):
     """Creates a hexagon at (0,0,0), subdivides it, and rotates it by 90 degrees."""
+    _t_start = time.time()
     verts = []
     faces = []
 
@@ -132,19 +134,37 @@ def create_hexagon(size, num_subdivisions = 1, name = "Hexagon"):
     mesh = bpy.data.meshes.new("Hexagon")
     obj = bpy.data.objects.new("Hexagon", mesh)
     bpy.context.collection.objects.link(obj)
+    _t = time.time()
     mesh.from_pydata(verts, [], faces)
     mesh.update()
+    print(f"  [hexagon] from_pydata+update: {time.time()-_t:.3f}s")
     bpy.context.view_layer.objects.active = obj
+    _t = time.time()
     bpy.ops.object.mode_set(mode='EDIT')
-    for _ in range(num_subdivisions):
-        bpy.ops.mesh.subdivide(number_cuts=1)  # 1 cut per loop for even refinement
+    print(f"  [hexagon] mode_set EDIT: {time.time()-_t:.3f}s")
+    if num_subdivisions > 0:
+        cuts = 2 ** num_subdivisions - 1
+        print(f"  [hexagon] subdivide_edges cuts={cuts} (N={num_subdivisions})…")
+        _t = time.time()
+        bm = bmesh.from_edit_mesh(mesh)
+        bmesh.ops.subdivide_edges(
+            bm, edges=list(bm.edges),
+            cuts=cuts,
+            use_grid_fill=True,
+        )
+        bmesh.update_edit_mesh(mesh)
+        print(f"  [hexagon] subdivide_edges: {time.time()-_t:.3f}s  verts={len(bm.verts)}")
+    _t = time.time()
     bpy.ops.object.mode_set(mode='OBJECT')
+    print(f"  [hexagon] mode_set OBJECT: {time.time()-_t:.3f}s")
     obj.name = name
     obj.data.name = name
+    print(f"  [hexagon] total: {time.time()-_t_start:.3f}s")
     return obj
 
 def create_rectangle(width, height, num_subdivisions = 1, name="Rectangle"):
     """Creates a rectangle and adds loop cuts to ensure cells are as square as possible."""
+    _t_start = time.time()
 
     cuts = 1 + 2**(num_subdivisions+1)
 
@@ -160,8 +180,10 @@ def create_rectangle(width, height, num_subdivisions = 1, name="Rectangle"):
     mesh = bpy.data.meshes.new(name)
     obj = bpy.data.objects.new(name, mesh)
     bpy.context.collection.objects.link(obj)
+    _t = time.time()
     mesh.from_pydata(verts, [], faces)
     mesh.update()
+    print(f"  [rectangle] from_pydata+update: {time.time()-_t:.3f}s")
 
     # 2. Calculate cuts needed to keep cells square
     target_cell_size = width/cuts
@@ -169,14 +191,19 @@ def create_rectangle(width, height, num_subdivisions = 1, name="Rectangle"):
 
     # 3. Apply the cuts
     bpy.context.view_layer.objects.active = obj
+    _t = time.time()
     bpy.ops.object.mode_set(mode='EDIT')
+    print(f"  [rectangle] mode_set EDIT: {time.time()-_t:.3f}s")
 
     bm = bmesh.from_edit_mesh(mesh)
 
     # Subdivide horizontal edges (cuts along Width)
     horizontal_edges = [e for e in bm.edges if e.verts[0].co.y == e.verts[1].co.y]
     if num_subdivisions > 0:
+        print(f"  [rectangle] subdivide horizontal cuts={cuts} (N={num_subdivisions})…")
+        _t = time.time()
         bmesh.ops.subdivide_edges(bm, edges=horizontal_edges, cuts=cuts, use_grid_fill=True)
+        print(f"  [rectangle] subdivide horizontal: {time.time()-_t:.3f}s")
 
     bm.verts.ensure_lookup_table()
     bm.edges.ensure_lookup_table()
@@ -184,10 +211,16 @@ def create_rectangle(width, height, num_subdivisions = 1, name="Rectangle"):
 
     vertical_edges = [e for e in bm.edges if abs(e.verts[0].co.x - e.verts[1].co.x) < 0.001]
     if cuts_y > 0:
+        print(f"  [rectangle] subdivide vertical cuts={cuts_y}…")
+        _t = time.time()
         bmesh.ops.subdivide_edges(bm, edges=vertical_edges, cuts=cuts_y, use_grid_fill=True)
+        print(f"  [rectangle] subdivide vertical: {time.time()-_t:.3f}s  verts={len(bm.verts)}")
 
     bmesh.update_edit_mesh(mesh)
+    _t = time.time()
     bpy.ops.object.mode_set(mode='OBJECT')
+    print(f"  [rectangle] mode_set OBJECT: {time.time()-_t:.3f}s")
+    print(f"  [rectangle] total: {time.time()-_t_start:.3f}s")
 
     return obj
 
@@ -281,6 +314,7 @@ def create_heart(size, num_subdivisions = 1, name = "Heart"):
     return obj
 
 def create_circle(radius, num_subdivisions = 1, name = "Circle", num_segments=64):
+    _t_start = time.time()
 
     # Ensure we are in Object Mode
     try:
@@ -310,26 +344,47 @@ def create_circle(radius, num_subdivisions = 1, name = "Circle", num_segments=64
     edges = [(i, (i + 1) % num_segments) for i in range(num_segments)]
 
     # Create the mesh from data
+    _t = time.time()
     mesh.from_pydata(verts, edges, [])  # No center vertex, no faces yet
     mesh.update()
+    print(f"  [circle] from_pydata+update: {time.time()-_t:.3f}s")
 
     # Make the object active and switch to Edit Mode
     bpy.context.view_layer.objects.active = obj
+    _t = time.time()
     bpy.ops.object.mode_set(mode='EDIT')
+    print(f"  [circle] mode_set EDIT: {time.time()-_t:.3f}s")
 
     # Select all vertices and fill the circle
     bpy.ops.mesh.select_all(action='SELECT')
+    _t = time.time()
     bpy.ops.mesh.fill_grid()
+    print(f"  [circle] fill_grid: {time.time()-_t:.3f}s")
 
-    for _ in range(num_subdivisions-3):
-        bpy.ops.mesh.subdivide(number_cuts=1)  # 1 cut per loop for even refinement
+    _sub_iters = num_subdivisions - 3
+    if _sub_iters > 0:
+        cuts = 2 ** _sub_iters - 1
+        print(f"  [circle] subdivide_edges cuts={cuts} (N={num_subdivisions}, sub_iters={_sub_iters})…")
+        _t = time.time()
+        bm = bmesh.from_edit_mesh(mesh)
+        bmesh.ops.subdivide_edges(
+            bm, edges=list(bm.edges),
+            cuts=cuts,
+            use_grid_fill=True,
+        )
+        bmesh.update_edit_mesh(mesh)
+        print(f"  [circle] subdivide_edges: {time.time()-_t:.3f}s  verts={len(bm.verts)}")
 
     # Switch back to Object Mode
+    _t = time.time()
     bpy.ops.object.mode_set(mode='OBJECT')
+    print(f"  [circle] mode_set OBJECT: {time.time()-_t:.3f}s")
+    print(f"  [circle] total: {time.time()-_t_start:.3f}s")
 
     return obj
 
 def create_ellipse(radius, num_subdivisions = 1, name = "Ellipse", aspect_ratio = 0.75, num_segments=64, ):
+    _t_start = time.time()
     # Ensure we are in Object Mode
     try:
         bpy.ops.object.mode_set(mode='OBJECT')
@@ -358,26 +413,48 @@ def create_ellipse(radius, num_subdivisions = 1, name = "Ellipse", aspect_ratio 
     edges = [(i, (i + 1) % num_segments) for i in range(num_segments)]
 
     # Create the mesh from data
+    _t = time.time()
     mesh.from_pydata(verts, edges, [])  # No center vertex, no faces yet
     mesh.update()
+    print(f"  [ellipse] from_pydata+update: {time.time()-_t:.3f}s")
 
     # Make the object active and switch to Edit Mode
     bpy.context.view_layer.objects.active = obj
+    _t = time.time()
     bpy.ops.object.mode_set(mode='EDIT')
+    print(f"  [ellipse] mode_set EDIT: {time.time()-_t:.3f}s")
 
     # Select all vertices and fill the circle
     bpy.ops.mesh.select_all(action='SELECT')
+    _t = time.time()
     bpy.ops.mesh.fill_grid()
+    print(f"  [ellipse] fill_grid: {time.time()-_t:.3f}s")
 
-    for _ in range(num_subdivisions-3):
-        bpy.ops.mesh.subdivide(number_cuts=1)  # 1 cut per loop for even refinement
+    _sub_iters = num_subdivisions - 3
+    if _sub_iters > 0:
+        cuts = 2 ** _sub_iters - 1
+        print(f"  [ellipse] subdivide_edges cuts={cuts} (N={num_subdivisions}, sub_iters={_sub_iters})…")
+        _t = time.time()
+        bm = bmesh.from_edit_mesh(mesh)
+        bmesh.ops.subdivide_edges(
+            bm, edges=list(bm.edges),
+            cuts=cuts,
+            use_grid_fill=True,
+        )
+        bmesh.update_edit_mesh(mesh)
+        print(f"  [ellipse] subdivide_edges: {time.time()-_t:.3f}s  verts={len(bm.verts)}")
 
     # Switch back to Object Mode
+    _t = time.time()
     bpy.ops.object.mode_set(mode='OBJECT')
+    print(f"  [ellipse] mode_set OBJECT: {time.time()-_t:.3f}s")
 
     obj.scale.y *= aspect_ratio
 
+    _t = time.time()
     bpy.ops.object.transform_apply(location=False, rotation=False, scale=True)
+    print(f"  [ellipse] transform_apply: {time.time()-_t:.3f}s")
+    print(f"  [ellipse] total: {time.time()-_t_start:.3f}s")
 
 
     return obj
@@ -385,6 +462,7 @@ def create_ellipse(radius, num_subdivisions = 1, name = "Ellipse", aspect_ratio 
 def create_octagon(size, num_subdivisions = 1, name = "Octagon"):
 
     """Creates a hexagon at (0,0,0), subdivides it, and rotates it by 90 degrees."""
+    _t_start = time.time()
     verts = []
     faces = []
     for i in range(8):
@@ -397,15 +475,32 @@ def create_octagon(size, num_subdivisions = 1, name = "Octagon"):
     mesh = bpy.data.meshes.new("Hexagon")
     obj = bpy.data.objects.new("Hexagon", mesh)
     bpy.context.collection.objects.link(obj)
+    _t = time.time()
     mesh.from_pydata(verts, [], faces)
     mesh.update()
+    print(f"  [octagon] from_pydata+update: {time.time()-_t:.3f}s")
     bpy.context.view_layer.objects.active = obj
+    _t = time.time()
     bpy.ops.object.mode_set(mode='EDIT')
-    for _ in range(num_subdivisions):
-        bpy.ops.mesh.subdivide(number_cuts=1)  # 1 cut per loop for even refinement
+    print(f"  [octagon] mode_set EDIT: {time.time()-_t:.3f}s")
+    if num_subdivisions > 0:
+        cuts = 2 ** num_subdivisions - 1
+        print(f"  [octagon] subdivide_edges cuts={cuts} (N={num_subdivisions})…")
+        _t = time.time()
+        bm = bmesh.from_edit_mesh(mesh)
+        bmesh.ops.subdivide_edges(
+            bm, edges=list(bm.edges),
+            cuts=cuts,
+            use_grid_fill=True,
+        )
+        bmesh.update_edit_mesh(mesh)
+        print(f"  [octagon] subdivide_edges: {time.time()-_t:.3f}s  verts={len(bm.verts)}")
+    _t = time.time()
     bpy.ops.object.mode_set(mode='OBJECT')
+    print(f"  [octagon] mode_set OBJECT: {time.time()-_t:.3f}s")
     obj.name = name
     obj.data.name = name
+    print(f"  [octagon] total: {time.time()-_t_start:.3f}s")
     return obj
 
 def col_create_line_mesh(name, coords):

--- a/TrailPrint3D/utils/terrain.py
+++ b/TrailPrint3D/utils/terrain.py
@@ -13,7 +13,7 @@ _COLORING_EMPTY = object()
 _COLORING_PAINTED = object()
 
 
-def _fetch_tiles_parallel(tasks, kind, semaphore, max_workers=4):
+def _fetch_tiles_parallel(tasks, kind, semaphore, settings=None, max_workers=4):
     """Fetch a list of OSM tiles concurrently, honouring Overpass rate limits.
 
     Parameters
@@ -22,6 +22,9 @@ def _fetch_tiles_parallel(tasks, kind, semaphore, max_workers=4):
     kind       : OSM feature kind string ('WATER', 'FOREST', …)
     semaphore  : threading.Semaphore — limits concurrent live requests to the
                  Overpass API (callers typically use Semaphore(2))
+    settings   : OsmFetchSettings snapshot read on the main thread before this
+                 function is called.  Passed through to fetch_osm_data so that
+                 worker threads never touch bpy.context.
     max_workers: thread-pool size (default 4)
 
     Returns
@@ -41,7 +44,8 @@ def _fetch_tiles_parallel(tasks, kind, semaphore, max_workers=4):
     def _fetch_one(bbox):
         with semaphore:
             try:
-                result = fetch_osm_data(bbox, kind, return_cache_status=True)
+                result = fetch_osm_data(bbox, kind, return_cache_status=True,
+                                        settings=settings)
             except Exception as e:
                 print(f"[_fetch_tiles_parallel] tile {bbox} failed: {e}")
                 return
@@ -61,7 +65,7 @@ def _fetch_tiles_parallel(tasks, kind, semaphore, max_workers=4):
     return results
 
 
-def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, max_workers=8):
+def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, settings=None, max_workers=8):
     """Fetch all active OSM kinds × all tiles in one parallel batch.
 
     Unlike calling _fetch_tiles_parallel per kind inside a sequential loop,
@@ -73,6 +77,9 @@ def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, max_workers=8):
     ----------
     kind_task_pairs : list of (kind_str, tasks_list) — one entry per active kind
     semaphore       : threading.Semaphore shared across all kinds
+    settings        : OsmFetchSettings snapshot read on the main thread.  Passed
+                      through to fetch_osm_data so worker threads never touch
+                      bpy.context.
     max_workers     : total pool size (default 8)
 
     Returns
@@ -94,7 +101,8 @@ def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, max_workers=8):
     def _fetch_one(kind, bbox):
         with semaphore:
             try:
-                result = fetch_osm_data(bbox, kind, return_cache_status=True)
+                result = fetch_osm_data(bbox, kind, return_cache_status=True,
+                                        settings=settings)
             except Exception as e:
                 print(f"[_fetch_all_kinds_parallel] {kind} {bbox} failed: {e}")
                 return
@@ -549,9 +557,96 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
         biggestArea = 0
         tol = 0.1
 
+        if elementMode == "PAINT":
+            # ── PAINT-mode fast path ──────────────────────────────────────────
+            # Skip per-object MANIFOLD boolean against terrain.
+            # color_map_faces_by_terrain builds its BVH from the cutter's LOCAL
+            # mesh (world transform is not applied). OSM polygons sit at Z=0 in
+            # local space (objects are at origin, so local == world). We extrude
+            # them to (terrain_max_z + 50) so the top face is:
+            #   • above the terrain  (> terrain_max_z)
+            #   • within ray range   (ray distance=100, starts at face_z-5)
+            map_world_verts = [map.matrix_world @ Vector(v) for v in map.bound_box]
+            terrain_max_z = max(v.z for v in map_world_verts)
+            extrude_z = terrain_max_z + 50.0
+            print(f"  [PAINT fast path] terrain_max_z={terrain_max_z:.2f}  extrude_z={extrude_z:.2f}")
+
+            _t_paint_fast = time.time()
+            paint_cutters = []
+            for tobj in list(created_objects):
+                area01 = getBottomFacesArea(tobj)
+                if area01 < col_Area*3 and "OpenObject_" in tobj.name:
+                    bpy.data.objects.remove(tobj, do_unlink=True)
+                    continue
+                if area01 < col_Area and "coloredObject_" in tobj.name:
+                    bpy.data.objects.remove(tobj, do_unlink=True)
+                    continue
+                mesh = tobj.data
+                bm = bmesh.new()
+                bm.from_mesh(mesh)
+                if not bm.faces:
+                    bm.free()
+                    bpy.data.objects.remove(tobj, do_unlink=True)
+                    continue
+                biggestArea = max(biggestArea, sum(f.calc_area() for f in bm.faces))
+                geom = bm.faces[:]
+                ret = bmesh.ops.extrude_face_region(bm, geom=geom)
+                extruded_verts = [v for v in ret["geom"] if isinstance(v, bmesh.types.BMVert)]
+                # Extrude to just above terrain so top face falls within the
+                # 100-unit ray distance used by color_map_faces_by_terrain.
+                bmesh.ops.translate(bm, verts=extruded_verts, vec=Vector((0, 0, extrude_z)))
+                bm.to_mesh(mesh)
+                bm.free()
+                # Keep location at (0,0,0) — local == world, BVH matches ray space.
+                paint_cutters.append(tobj)
+            # ribbon_objects were bmesh-merged into created_objects above as
+            # "OpenObject_merged" — do NOT re-iterate here (stale refs).
+
+            print(f"  [coloring_main] PAINT extrude ({kind}, {len(paint_cutters)} objs): {time.time()-_t_paint_fast:.3f}s")
+
+            for obj in list(negative_object):
+                bpy.data.objects.remove(obj, do_unlink=True)
+            negative_object.clear()
+            ribbon_objects.clear()
+
+            if not paint_cutters:
+                if _api_empty:
+                    return _COLORING_EMPTY
+                return None
+
+            _t_merge = time.time()
+            cutter = merge_objects(paint_cutters, name=f"{name}_{kind}")
+            print(f"  [coloring_main] PAINT merge ({kind}): {time.time()-_t_merge:.3f}s")
+
+            if cutter is None:
+                return None
+
+            writeMetadata(cutter, kind)
+            mat = bpy.data.materials.get(KIND_MATERIAL_OVERRIDE.get(kind, kind))
+            cutter.data.materials.clear()
+            cutter.data.materials.append(mat)
+
+            if _ov.active:
+                _ov.update(message=f"{kind.capitalize()}: painting terrain faces")
+
+            print(f"PAINTING ({kind})")
+            _t_paint = time.time()
+            color_map_faces_by_terrain(map, cutter)
+            mesh_data = cutter.data
+            bpy.data.objects.remove(cutter, do_unlink=True)
+            bpy.data.meshes.remove(mesh_data)
+            print(f"  [coloring_main] PAINT total ({kind}): {time.time()-_t_paint:.3f}s")
+            return _COLORING_PAINTED
+            # ── end PAINT-mode fast path ──────────────────────────────────────
+
+        KIND_MATERIAL_OVERRIDE = {
+            "SCREE": "MOUNTAIN",
+        }
+
         # Per-object extrude + MANIFOLD boolean — no recalculateNormals (avoids mode-switch cost).
         _t_proc_loop = time.time()
         DOWN = Vector((0, 0, -1))
+        _t_extrude_total = _t_bool_total = _t_split_total = 0.0
         for tobj in list(created_objects):
             area01 = getBottomFacesArea(tobj)
             if area01 < col_Area*3 and "OpenObject_" in tobj.name:
@@ -561,6 +656,7 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                 bpy.data.objects.remove(tobj, do_unlink=True)
                 continue
             mesh = tobj.data
+            _ta = time.time()
             bm = bmesh.new()
             bm.from_mesh(mesh)
             if not bm.faces:
@@ -577,8 +673,10 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
             bm.to_mesh(mesh)
             bm.free()
             tobj.location.z -= 1
+            _t_extrude_total += time.time() - _ta
 
             # Per-object MANIFOLD boolean intersect with the map.
+            _tb = time.time()
             bool_mod = tobj.modifiers.new(name="Boolean", type='BOOLEAN')
             bool_mod.object = map
             bool_mod.operation = 'INTERSECT'
@@ -590,12 +688,14 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
             old_mesh = tobj.data
             tobj.data = new_mesh
             bpy.data.meshes.remove(old_mesh)
+            _t_bool_total += time.time() - _tb
 
             if not new_mesh.vertices:
                 bpy.data.objects.remove(tobj, do_unlink=True)
                 continue
 
             # Split loose parts, fix normals, filter by area.
+            _tc = time.time()
             for zobj in _split_loose(tobj):
                 mesh_area = getBottomFacesArea(zobj)
                 if mesh_area < col_Area:
@@ -617,7 +717,9 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                 bm.to_mesh(zmesh)
                 bm.free()
                 created_objects_booleaned.append(zobj)
+            _t_split_total += time.time() - _tc
         print(f"  [coloring_main] process objects ({kind}, {len(created_objects)} objs): {time.time()-_t_proc_loop:.3f}s  {len(created_objects_booleaned)} results")
+        print(f"    extrude={_t_extrude_total:.3f}s  boolean={_t_bool_total:.3f}s  split={_t_split_total:.3f}s  other={time.time()-_t_proc_loop-_t_extrude_total-_t_bool_total-_t_split_total:.3f}s")
 
         for cntr, tobj in enumerate(list(negative_object), start = 1):
             area, new_objs = _process_coloring_object(tobj,map,tol, extrudeVal = 200)
@@ -627,7 +729,8 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                 to.scale.z *= 2
 
             created_negatives_booleaned.extend(new_objs)
-        print("subtracting negatives from element")
+        print(f"subtracting negatives from element ({len(negative_object)} objs)")
+        _t_neg = time.time()
         if created_negatives_booleaned:
             # Union all negatives into one cutter so each positive needs only one boolean op
             if len(created_negatives_booleaned) > 1:
@@ -639,7 +742,7 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                     boolean_operation(o1, merged_negative)
                     recalculateNormals(o1)
             bpy.data.objects.remove(merged_negative, do_unlink=True)
-        print("finished subtracting")
+        print(f"finished subtracting ({time.time()-_t_neg:.3f}s)")
 
         if biggestArea == 0:
             print("No Water Found on Tile")
@@ -686,9 +789,6 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
 
         if merged_object:
             writeMetadata(merged_object, kind)
-            KIND_MATERIAL_OVERRIDE = {
-                "SCREE": "MOUNTAIN",
-            }
             mat = bpy.data.materials.get(KIND_MATERIAL_OVERRIDE.get(kind, kind))
             merged_object.data.materials.clear()
             merged_object.data.materials.append(mat)
@@ -742,25 +842,26 @@ def color_map_faces_by_terrain(map_obj, terrain_obj, up_threshold=0.05):
 
     recalculateNormals(map_obj)
 
-    terrain_obj.location.z = 10
-    bpy.context.view_layer.update()
-
     # Ensure both have mesh data
     map_mesh = map_obj.data
-    terrain_mesh = terrain_obj.data
 
-    # Build bmesh for Map
+    # Build bmesh for Map — read LOCAL mesh, transform centers to WORLD space via matrix_world
     bm = bmesh.new()
     bm.from_mesh(map_mesh)
     bm.faces.ensure_lookup_table()
+    mw_map = map_obj.matrix_world
 
     depsgraph = bpy.context.evaluated_depsgraph_get()
     eval_obj = terrain_obj.evaluated_get(depsgraph)
 
     eval_mesh = eval_obj.to_mesh()
 
+    # Build BVH in WORLD space by applying the cutter's matrix_world to each vertex
     bm2 = bmesh.new()
     bm2.from_mesh(eval_mesh)
+    mw_terrain = terrain_obj.matrix_world
+    for v in bm2.verts:
+        v.co = mw_terrain @ v.co
 
     _t_bvh = time.time()
     bvh = bvhtree.BVHTree.FromBMesh(bm2)
@@ -788,7 +889,7 @@ def color_map_faces_by_terrain(map_obj, terrain_obj, up_threshold=0.05):
         dot = normal.dot(up)
         # Only consider faces facing upward
         if dot > up_threshold:
-            center = f.calc_center_median()
+            center = mw_map @ f.calc_center_median()  # world space
             center.z -= 5
             loc, norm, idx, dist = bvh.ray_cast(center, up,100)
 

--- a/TrailPrint3D/utils/terrain.py
+++ b/TrailPrint3D/utils/terrain.py
@@ -3,6 +3,8 @@ import bpy  # type: ignore
 import bmesh  # type: ignore
 import math
 import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from mathutils import Vector, Matrix, bvhtree  # type: ignore
 from .. import progress as _progress
 
@@ -10,7 +12,109 @@ _COLORING_EMPTY = object()
 _COLORING_PAINTED = object()
 
 
-def coloring_main(map, kind = "WATER"):
+def _fetch_tiles_parallel(tasks, kind, semaphore, max_workers=4):
+    """Fetch a list of OSM tiles concurrently, honouring Overpass rate limits.
+
+    Parameters
+    ----------
+    tasks      : list of (south, west, north, east) bbox tuples
+    kind       : OSM feature kind string ('WATER', 'FOREST', …)
+    semaphore  : threading.Semaphore — limits concurrent live requests to the
+                 Overpass API (callers typically use Semaphore(2))
+    max_workers: thread-pool size (default 4)
+
+    Returns
+    -------
+    dict mapping bbox tuple -> (data_dict, from_cache_bool)
+    Only tiles that fetched successfully are present in the result.
+
+    NOTE: bpy.* calls are forbidden inside this function — it runs on worker
+    threads.  All mesh-building still happens on the main thread in
+    coloring_main().
+    """
+    from .osm import fetch_osm_data  # deferred to avoid circular import
+
+    results = {}
+    lock = threading.Lock()
+
+    def _fetch_one(bbox):
+        with semaphore:
+            try:
+                result = fetch_osm_data(bbox, kind, return_cache_status=True)
+            except Exception as e:
+                print(f"[_fetch_tiles_parallel] tile {bbox} failed: {e}")
+                return
+        if result:
+            resp, from_cache = result
+            if resp:
+                with lock:
+                    results[bbox] = (resp, from_cache)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_fetch_one, bbox): bbox for bbox in tasks}
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc:
+                print(f"[_fetch_tiles_parallel] worker exception: {exc}")
+
+    return results
+
+
+def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, max_workers=8):
+    """Fetch all active OSM kinds × all tiles in one parallel batch.
+
+    Unlike calling _fetch_tiles_parallel per kind inside a sequential loop,
+    this function submits every (kind, tile) pair into a single thread pool so
+    all network round-trips overlap.  The shared *semaphore* still caps the
+    number of concurrent live Overpass requests (callers use Semaphore(2)).
+
+    Parameters
+    ----------
+    kind_task_pairs : list of (kind_str, tasks_list) — one entry per active kind
+    semaphore       : threading.Semaphore shared across all kinds
+    max_workers     : total pool size (default 8)
+
+    Returns
+    -------
+    dict[kind_str -> dict[bbox -> (data_dict, from_cache_bool)]]
+    Kinds with no successful tiles are present as empty dicts.
+    """
+    from .osm import fetch_osm_data  # deferred to avoid circular import
+
+    results = {kind: {} for kind, _ in kind_task_pairs}
+    lock = threading.Lock()
+
+    all_tasks = [
+        (kind, bbox)
+        for kind, bboxes in kind_task_pairs
+        for bbox in bboxes
+    ]
+
+    def _fetch_one(kind, bbox):
+        with semaphore:
+            try:
+                result = fetch_osm_data(bbox, kind, return_cache_status=True)
+            except Exception as e:
+                print(f"[_fetch_all_kinds_parallel] {kind} {bbox} failed: {e}")
+                return
+        if result:
+            resp, from_cache = result
+            if resp:
+                with lock:
+                    results[kind][bbox] = (resp, from_cache)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_fetch_one, kind, bbox): (kind, bbox) for kind, bbox in all_tasks}
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc:
+                kind, bbox = futures[fut]
+                print(f"[_fetch_all_kinds_parallel] worker exception for {kind}: {exc}")
+
+    return results
+
+
+def coloring_main(map, kind="WATER", prefetched_tiles=None):
     from .osm import fetch_osm_data, build_osm_nodes, extract_multipolygon_bodies, calculate_polygon_area_2d, is_bbox_overlapping  # deferred to avoid circular import at load time
     from .geo import convert_to_blender_coordinates  # deferred to avoid circular import at load time
     from .primitives import col_create_face_mesh, create_ribbon_mesh, create_rectangle, create_hexagon, create_heart, create_octagon, create_circle, create_ellipse  # deferred to avoid circular import at load time
@@ -74,7 +178,7 @@ def coloring_main(map, kind = "WATER"):
 
     cntr = 0
     maxcntr = lats * lons
-    if lats * lons < 20:
+    if lats * lons < 20 or prefetched_tiles is not None:
         for k in range(lats):
             for l in range(lons):
                 cntr = (k) * lons + l + 1
@@ -92,12 +196,20 @@ def coloring_main(map, kind = "WATER"):
                 data = []
                 print("Fetching OSM")
                 try:
-                    result = fetch_osm_data(bbox, kind, return_cache_status=True)
-                    if not result:
-                        continue
-                    resp, from_cache = result
-                    if not resp:
-                        continue
+                    if prefetched_tiles is not None:
+                        tile_result = prefetched_tiles.get(bbox)
+                        if tile_result is None:
+                            continue
+                        resp, from_cache = tile_result
+                        if not resp:
+                            continue
+                    else:
+                        result = fetch_osm_data(bbox, kind, return_cache_status=True)
+                        if not result:
+                            continue
+                        resp, from_cache = result
+                        if not resp:
+                            continue
 
                 except Exception as e:
                     show_message_box(f"Something went wrong with fetching OSM data: {e}")
@@ -184,8 +296,8 @@ def coloring_main(map, kind = "WATER"):
                             ribbon_objects.append(tobj)
                             waterCreated += 1
 
-                if not from_cache:
-                    time.sleep(5)  # Pause to prevent request throttling
+                if not from_cache and prefetched_tiles is None:
+                    time.sleep(5)  # Pause to prevent request throttling (skipped when worker pre-fetched)
     else:
         print(f"Region too big. Cant Fetch All {kind} Sources")
         return None
@@ -209,14 +321,29 @@ def coloring_main(map, kind = "WATER"):
     if ribbon_objects:
         valid_ribbons = [o for o in ribbon_objects if o and o.type == 'MESH']
         if valid_ribbons:
-            bpy.ops.object.select_all(action='DESELECT')
-            for ro in valid_ribbons:
-                ro.select_set(True)
-            bpy.context.view_layer.objects.active = valid_ribbons[0]
-            bpy.ops.object.join()
-            merged_ribbons = bpy.context.view_layer.objects.active
-            merged_ribbons.name = "OpenObject_merged"
-            created_objects.append(merged_ribbons)
+            if len(valid_ribbons) == 1:
+                valid_ribbons[0].name = "OpenObject_merged"
+                created_objects.append(valid_ribbons[0])
+            else:
+                # Merge all ribbon meshes using bmesh (no bpy.ops.object.join)
+                bm_merged = bmesh.new()
+                target_world_inv = valid_ribbons[0].matrix_world.inverted()
+                bm_merged.from_mesh(valid_ribbons[0].data)
+                for ro in valid_ribbons[1:]:
+                    bm_part = bmesh.new()
+                    bm_part.from_mesh(ro.data)
+                    xform = target_world_inv @ ro.matrix_world
+                    bmesh.ops.transform(bm_part, verts=bm_part.verts[:], matrix=xform)
+                    tmp_mesh = bpy.data.meshes.new("_tp3d_merge_tmp")
+                    bm_part.to_mesh(tmp_mesh)
+                    bm_part.free()
+                    bm_merged.from_mesh(tmp_mesh)
+                    bpy.data.meshes.remove(tmp_mesh)
+                    bpy.data.objects.remove(ro, do_unlink=True)
+                bm_merged.to_mesh(valid_ribbons[0].data)
+                bm_merged.free()
+                valid_ribbons[0].name = "OpenObject_merged"
+                created_objects.append(valid_ribbons[0])
 
     #Make sure the flat faces have the correct normal orientation
     UP = Vector((0,0,1))
@@ -244,15 +371,72 @@ def coloring_main(map, kind = "WATER"):
             bm.free()
 
 
+    def _split_loose(obj):
+        """Split obj into per-connected-component objects. Removes obj and returns list."""
+        src_mesh = obj.data
+        bm_src = bmesh.new()
+        bm_src.from_mesh(src_mesh)
+        bm_src.verts.ensure_lookup_table()
+
+        visited = set()
+        components = []
+        for start in bm_src.verts:
+            if start.index in visited:
+                continue
+            comp = set()
+            stack = [start]
+            while stack:
+                v = stack.pop()
+                if v.index in visited:
+                    continue
+                visited.add(v.index)
+                comp.add(v.index)
+                for edge in v.link_edges:
+                    other = edge.other_vert(v)
+                    if other.index not in visited:
+                        stack.append(other)
+            components.append(comp)
+
+        collection = obj.users_collection[0] if obj.users_collection else bpy.context.scene.collection
+        world_matrix = obj.matrix_world.copy()
+        parts = []
+        for comp_indices in components:
+            comp_faces = [f for f in bm_src.faces
+                          if all(v.index in comp_indices for v in f.verts)]
+            bm_new = bmesh.new()
+            idx_map = {}
+            for vi in comp_indices:
+                nv = bm_new.verts.new(bm_src.verts[vi].co.copy())
+                idx_map[vi] = nv
+            bm_new.verts.ensure_lookup_table()
+            for f in comp_faces:
+                try:
+                    bm_new.faces.new([idx_map[v.index] for v in f.verts])
+                except ValueError:
+                    pass  # duplicate face edge — skip
+            new_mesh = bpy.data.meshes.new(obj.name)
+            bm_new.to_mesh(new_mesh)
+            bm_new.free()
+            part = bpy.data.objects.new(obj.name, new_mesh)
+            part.matrix_world = world_matrix
+            collection.objects.link(part)
+            parts.append(part)
+
+        bm_src.free()
+        bpy.data.objects.remove(obj, do_unlink=True)
+        return parts
+
     def _process_coloring_object(tobj, map_obj, tol=0.1, extrudeVal = 200):
         """Extrude, boolean-intersect with map, separate loose parts, fix normals.
         Returns (area, [resulting_objects]). Removes tobj if it becomes empty."""
+        _t_pco = time.time()
 
         bpy.ops.object.select_all(action='DESELECT')
 
         mesh = tobj.data
 
         # Compute area and extrude in a single bmesh pass
+        _t = time.time()
         bm = bmesh.new()
         bm.from_mesh(mesh)
         if not bm.faces:
@@ -266,11 +450,13 @@ def coloring_main(map, kind = "WATER"):
         bmesh.ops.translate(bm, verts=extruded_verts, vec=Vector((0, 0, extrudeVal)))
         bm.to_mesh(mesh)
         bm.free()
+        print(f"    [pco:{tobj.name}] extrude: {time.time()-_t:.3f}s")
 
         tobj.location.z -= 1
         recalculateNormals(tobj)
 
         # Boolean intersect with map
+        _t = time.time()
         bool_mod = tobj.modifiers.new(name="Boolean", type='BOOLEAN')
         bool_mod.object = map_obj
         bool_mod.operation = 'INTERSECT'
@@ -283,6 +469,7 @@ def coloring_main(map, kind = "WATER"):
         old_mesh = tobj.data
         tobj.data = new_mesh
         bpy.data.meshes.remove(old_mesh)
+        print(f"    [pco:{tobj.name}] boolean intersect (MANIFOLD): {time.time()-_t:.3f}s  verts={len(new_mesh.vertices)}")
 
         # Mark lowest vertices
         bm = bmesh.new()
@@ -304,17 +491,13 @@ def coloring_main(map, kind = "WATER"):
 
         recalculateNormals(tobj)
 
-        # Separate loose parts
-        bpy.ops.object.select_all(action='DESELECT')
-        tobj.select_set(True)
-        bpy.context.view_layer.objects.active = tobj
-        bpy.ops.object.mode_set(mode='EDIT')
-        bpy.ops.mesh.separate(type='LOOSE')
-        bpy.ops.object.mode_set(mode='OBJECT')
+        # Separate loose parts — uses outer _split_loose helper
+        _t = time.time()
+        _tobj_name = tobj.name  # capture before _split_loose removes the object
 
         result_objects = []
         objects_to_remove = []
-        for zobj in bpy.context.selected_objects:
+        for zobj in _split_loose(tobj):
 
             mesh_area = getBottomFacesArea(zobj)
             if mesh_area < col_Area:
@@ -347,7 +530,8 @@ def coloring_main(map, kind = "WATER"):
 
         remove_objects(objects_to_remove)
 
-
+        print(f"    [pco:{_tobj_name}] split_loose: {time.time()-_t:.3f}s  parts={len(result_objects)}")
+        print(f"    [pco] total: {time.time()-_t_pco:.3f}s")
         return area, result_objects
 
 
@@ -364,21 +548,75 @@ def coloring_main(map, kind = "WATER"):
         biggestArea = 0
         tol = 0.1
 
-        for cntr, tobj in enumerate(list(created_objects), start=1):
+        # Per-object extrude + MANIFOLD boolean — no recalculateNormals (avoids mode-switch cost).
+        _t_proc_loop = time.time()
+        DOWN = Vector((0, 0, -1))
+        for tobj in list(created_objects):
             area01 = getBottomFacesArea(tobj)
             if area01 < col_Area*3 and "OpenObject_" in tobj.name:
-                print("Skipping OpenObject")
                 bpy.data.objects.remove(tobj, do_unlink=True)
                 continue
             if area01 < col_Area and "coloredObject_" in tobj.name:
-                print("Skipping ClosedObject")
+                bpy.data.objects.remove(tobj, do_unlink=True)
+                continue
+            mesh = tobj.data
+            bm = bmesh.new()
+            bm.from_mesh(mesh)
+            if not bm.faces:
+                bm.free()
+                bpy.data.objects.remove(tobj, do_unlink=True)
+                continue
+            biggestArea = max(biggestArea, sum(f.calc_area() for f in bm.faces))
+            geom = bm.faces[:]
+            ret = bmesh.ops.extrude_face_region(bm, geom=geom)
+            extruded_verts = [v for v in ret["geom"] if isinstance(v, bmesh.types.BMVert)]
+            bmesh.ops.translate(bm, verts=extruded_verts, vec=Vector((0, 0, 200)))
+            # Recalc normals via bmesh (no mode-switch overhead).
+            bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+            bm.to_mesh(mesh)
+            bm.free()
+            tobj.location.z -= 1
+
+            # Per-object MANIFOLD boolean intersect with the map.
+            bool_mod = tobj.modifiers.new(name="Boolean", type='BOOLEAN')
+            bool_mod.object = map
+            bool_mod.operation = 'INTERSECT'
+            bool_mod.solver = 'MANIFOLD'
+            depsgraph = bpy.context.evaluated_depsgraph_get()
+            eval_obj = tobj.evaluated_get(depsgraph)
+            new_mesh = bpy.data.meshes.new_from_object(eval_obj)
+            tobj.modifiers.clear()
+            old_mesh = tobj.data
+            tobj.data = new_mesh
+            bpy.data.meshes.remove(old_mesh)
+
+            if not new_mesh.vertices:
                 bpy.data.objects.remove(tobj, do_unlink=True)
                 continue
 
-            area, new_objs = _process_coloring_object(tobj, map, tol, extrudeVal= 150)
-            biggestArea = max(biggestArea, area)
-            created_objects_booleaned.extend(new_objs)
-
+            # Split loose parts, fix normals, filter by area.
+            for zobj in _split_loose(tobj):
+                mesh_area = getBottomFacesArea(zobj)
+                if mesh_area < col_Area:
+                    bpy.data.objects.remove(zobj, do_unlink=True)
+                    continue
+                zmesh = zobj.data
+                bm = bmesh.new()
+                bm.from_mesh(zmesh)
+                bm.normal_update()
+                lowest_face = None
+                lowest_z = float('inf')
+                for face in bm.faces:
+                    z = face.calc_center_median().z
+                    if z < lowest_z and face.calc_area() > 0:
+                        lowest_z = z
+                        lowest_face = face
+                if lowest_face and lowest_face.normal.dot(DOWN) <= 0:
+                    bmesh.ops.reverse_faces(bm, faces=bm.faces[:])
+                bm.to_mesh(zmesh)
+                bm.free()
+                created_objects_booleaned.append(zobj)
+        print(f"  [coloring_main] process objects ({kind}, {len(created_objects)} objs): {time.time()-_t_proc_loop:.3f}s  {len(created_objects_booleaned)} results")
 
         for cntr, tobj in enumerate(list(negative_object), start = 1):
             area, new_objs = _process_coloring_object(tobj,map,tol, extrudeVal = 200)
@@ -407,7 +645,9 @@ def coloring_main(map, kind = "WATER"):
             return
 
         print(f"{kind} objects to merge: {len(created_objects_booleaned)}")
+        _t_merge = time.time()
         merged_object = merge_objects(created_objects_booleaned)
+        print(f"  [coloring_main] merge_objects ({kind}): {time.time()-_t_merge:.3f}s")
 
         bpy.ops.object.origin_set(type='ORIGIN_CURSOR', center='MEDIAN')
 
@@ -456,7 +696,8 @@ def coloring_main(map, kind = "WATER"):
             _ov.update(message=f"{kind.capitalize()}: applying Element handling option ({elementMode})")
 
         if elementMode == "PAINT":
-            print("PAINTING")
+            print(f"PAINTING ({kind})")
+            _t_paint = time.time()
             recalculateNormals(map)
             merged_object.location.z += 1
             color_map_faces_by_terrain(map, merged_object)
@@ -465,6 +706,7 @@ def coloring_main(map, kind = "WATER"):
             #Delete the elements afterwards
             bpy.data.objects.remove(merged_object, do_unlink=True)
             bpy.data.meshes.remove(mesh_data)
+            print(f"  [coloring_main] PAINT total ({kind}): {time.time()-_t_paint:.3f}s")
 
     for area in bpy.context.screen.areas:
         if area.type == 'VIEW_3D':  # make sure it's a 3D Viewport
@@ -519,7 +761,9 @@ def color_map_faces_by_terrain(map_obj, terrain_obj, up_threshold=0.05):
     bm2 = bmesh.new()
     bm2.from_mesh(eval_mesh)
 
+    _t_bvh = time.time()
     bvh = bvhtree.BVHTree.FromBMesh(bm2)
+    print(f"  [color_faces] BVH build: {time.time()-_t_bvh:.3f}s  ({len(bm2.faces)} terrain faces)")
 
     # Get or create a material for terrain color
     if terrain_obj.active_material:
@@ -536,6 +780,7 @@ def color_map_faces_by_terrain(map_obj, terrain_obj, up_threshold=0.05):
     up = Vector((0, 0, 1))
     colored_count = 0
 
+    _t_raycast = time.time()
     i = 0
     for i, f in enumerate(bm.faces):
         normal = f.normal.normalized()
@@ -550,11 +795,14 @@ def color_map_faces_by_terrain(map_obj, terrain_obj, up_threshold=0.05):
                 # Assign terrain material to this face
                 f.material_index = mat_index
                 colored_count += 1
+    print(f"  [color_faces] ray-cast loop: {time.time()-_t_raycast:.3f}s  ({i+1} faces checked, {colored_count} colored)")
 
+    _t_sync = time.time()
     bm.to_mesh(map_mesh)
     bm.free()
     bm2.free()
     eval_obj.to_mesh_clear()
+    print(f"  [color_faces] bm.to_mesh sync: {time.time()-_t_sync:.3f}s")
     print(f"Colored {colored_count} faces on {map_obj.name} based on {terrain_obj.name}")
 
 
@@ -609,10 +857,11 @@ def createOcean(bboxBigger, waterHeight, scaleHor, landpoints, baseplate, tile, 
     from .mesh_ops import projection  # deferred to avoid circular import at load time
     from .primitives import create_rectangle  # deferred to avoid circular import at load time
 
+    _t_ocean = time.time()
     coastcurve = create_element(bboxBigger, waterHeight, scaleHor, "COASTLINE", baseHeight * 3)
-    set_origin_to_3d_cursor(coastcurve)
-    print("coastcurve created")
-    if coastcurve != None:
+    print(f"  [ocean] create_element (coastline fetch): {time.time()-_t_ocean:.3f}s")
+    if coastcurve is not None:
+        set_origin_to_3d_cursor(coastcurve)
 
         shape = bpy.context.scene.tp3d.shape
         objSize = bpy.context.scene.tp3d.objSize
@@ -628,11 +877,12 @@ def createOcean(bboxBigger, waterHeight, scaleHor, landpoints, baseplate, tile, 
         coastobj.location.z = 0
 
         flip_override = bpy.context.scene.tp3d.el_oFlip
+        _t_cut = time.time()
         merged_object = cut_coastline(coastcurve, coastobj, land_hints=landpoints, flip_override=flip_override)
+        print(f"  [ocean] cut_coastline: {time.time()-_t_cut:.3f}s  ({len(merged_object.data.polygons) if merged_object else 0} faces)")
 
         #REMOVE THE CUTTER OBJECT
         remove_objects(coastcurve)
-        
 
         mat = bpy.data.materials.get("WATER")
         merged_object.data.materials.clear()
@@ -640,23 +890,34 @@ def createOcean(bboxBigger, waterHeight, scaleHor, landpoints, baseplate, tile, 
 
         elementMode = bpy.context.scene.tp3d.elementMode
         if elementMode == "PAINT":
+            _t_proj = time.time()
             projection("paint", tile, merged_object)
+            print(f"  [ocean] projection (paint): {time.time()-_t_proj:.3f}s")
+            print(f"  [ocean] total: {time.time()-_t_ocean:.3f}s")
             return None
         elif elementMode == "SINGLECOLORMODE" or elementMode == "SINGLECOLORMODE_REMESH":
+            _t_proj = time.time()
             projection("singleColorMode", tile, merged_object)
+            print(f"  [ocean] projection (singleColorMode): {time.time()-_t_proj:.3f}s")
             mat = bpy.data.materials.get("WATER")
             merged_object.data.materials.clear()
             merged_object.data.materials.append(mat)
+            print(f"  [ocean] total: {time.time()-_t_ocean:.3f}s")
             return merged_object
         elif elementMode == "SEPARATE":
+            _t_proj = time.time()
             projection("separate", tile, merged_object)
+            print(f"  [ocean] projection (separate): {time.time()-_t_proj:.3f}s")
             mat = bpy.data.materials.get("WATER")
             merged_object.data.materials.clear()
             merged_object.data.materials.append(mat)
+            print(f"  [ocean] total: {time.time()-_t_ocean:.3f}s")
             return merged_object
 
     else:
-        print("NO COASTCURVE FOR SOME REASON")
+        from .. import progress as _progress  # deferred to avoid circular import at load time
+        _progress.WarningsOverlay.add_warning("No coastline data found for this area — ocean layer skipped.", "warn")
+        return None
 
 
 def cut_coastline(curve_obj, target_obj, land_hints=None, flip_override=False):
@@ -817,7 +1078,9 @@ def cut_coastline(curve_obj, target_obj, land_hints=None, flip_override=False):
         # try applying modifier
         try:
             print("APPLYING MODIFIER")
+            _t_bool = time.time()
             bpy.ops.object.modifier_apply(modifier=bool_mod.name)
+            print(f"  [cut_coastline] boolean apply: {time.time()-_t_bool:.3f}s")
         except Exception as e:
             print("Warning: boolean modifier apply failed:", e)
             raise RuntimeError("Boolean operation failed: " + str(e))

--- a/TrailPrint3D/utils/terrain.py
+++ b/TrailPrint3D/utils/terrain.py
@@ -12,6 +12,11 @@ from .. import progress as _progress
 _COLORING_EMPTY = object()
 _COLORING_PAINTED = object()
 
+# Material name override for kinds whose material name differs from the kind string.
+KIND_MATERIAL_OVERRIDE = {
+    "SCREE": "MOUNTAIN",
+}
+
 
 def _fetch_tiles_parallel(tasks, kind, semaphore, settings=None, max_workers=4):
     """Fetch a list of OSM tiles concurrently, honouring Overpass rate limits.
@@ -638,10 +643,6 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
             print(f"  [coloring_main] PAINT total ({kind}): {time.time()-_t_paint:.3f}s")
             return _COLORING_PAINTED
             # ── end PAINT-mode fast path ──────────────────────────────────────
-
-        KIND_MATERIAL_OVERRIDE = {
-            "SCREE": "MOUNTAIN",
-        }
 
         # Per-object extrude + MANIFOLD boolean — no recalculateNormals (avoids mode-switch cost).
         _t_proc_loop = time.time()

--- a/TrailPrint3D/utils/terrain.py
+++ b/TrailPrint3D/utils/terrain.py
@@ -70,60 +70,70 @@ def _fetch_tiles_parallel(tasks, kind, semaphore, settings=None, max_workers=4):
     return results
 
 
-def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, settings=None, max_workers=8):
+def _fetch_all_kinds_parallel(kind_task_pairs, semaphore, settings=None, max_workers=4):
     """Fetch all active OSM kinds × all tiles in one parallel batch.
 
-    Unlike calling _fetch_tiles_parallel per kind inside a sequential loop,
-    this function submits every (kind, tile) pair into a single thread pool so
-    all network round-trips overlap.  The shared *semaphore* still caps the
-    number of concurrent live Overpass requests (callers use Semaphore(2)).
+    Each unique tile bbox is fetched with a **single** Overpass union request
+    that covers every active kind for that tile.  This replaces the previous
+    N-kinds × T-tiles individual request strategy and drastically reduces the
+    number of concurrent Overpass connections, avoiding rate-limit errors.
+
+    The shared *semaphore* still caps the number of live Overpass requests
+    (callers use Semaphore(2)); because each tile now maps to exactly one
+    request, the semaphore is acquired only during the actual network call.
 
     Parameters
     ----------
     kind_task_pairs : list of (kind_str, tasks_list) — one entry per active kind
-    semaphore       : threading.Semaphore shared across all kinds
+    semaphore       : threading.Semaphore shared across all tile workers
     settings        : OsmFetchSettings snapshot read on the main thread.  Passed
-                      through to fetch_osm_data so worker threads never touch
-                      bpy.context.
-    max_workers     : total pool size (default 8)
+                      through so worker threads never touch bpy.context.
+    max_workers     : thread-pool size (default 4; one request per tile now)
 
     Returns
     -------
     dict[kind_str -> dict[bbox -> (data_dict, from_cache_bool)]]
     Kinds with no successful tiles are present as empty dicts.
     """
-    from .osm import fetch_osm_data  # deferred to avoid circular import
+    from .osm import fetch_osm_combined  # deferred to avoid circular import
+
+    # ── Regroup: (kind, [bboxes]) → {bbox: [kinds]} ──────────────────────
+    tile_kinds: dict = {}
+    for kind, bboxes in kind_task_pairs:
+        for bbox in bboxes:
+            tile_kinds.setdefault(bbox, []).append(kind)
 
     results = {kind: {} for kind, _ in kind_task_pairs}
     lock = threading.Lock()
 
-    all_tasks = [
-        (kind, bbox)
-        for kind, bboxes in kind_task_pairs
-        for bbox in bboxes
-    ]
-
-    def _fetch_one(kind, bbox):
-        with semaphore:
-            try:
-                result = fetch_osm_data(bbox, kind, return_cache_status=True,
-                                        settings=settings)
-            except Exception as e:
-                print(f"[_fetch_all_kinds_parallel] {kind} {bbox} failed: {e}")
-                return
-        if result:
-            resp, from_cache = result
-            if resp:
-                with lock:
-                    results[kind][bbox] = (resp, from_cache)
+    def _fetch_tile(bbox, kinds):
+        # Acquire the shared semaphore before the network call (mirrors the
+        # original _fetch_one pattern so the semaphore correctly caps the
+        # number of concurrent live Overpass requests).
+        if semaphore is not None:
+            semaphore.acquire()
+        try:
+            tile_result = fetch_osm_combined(bbox, kinds, settings=settings)
+        except Exception as e:
+            print(f"[_fetch_all_kinds_parallel] tile {bbox} failed: {e}")
+            return
+        finally:
+            if semaphore is not None:
+                semaphore.release()
+        with lock:
+            for kind, (data, from_cache) in tile_result.items():
+                if data:
+                    results[kind][bbox] = (data, from_cache)
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {pool.submit(_fetch_one, kind, bbox): (kind, bbox) for kind, bbox in all_tasks}
+        futures = {
+            pool.submit(_fetch_tile, bbox, kinds): bbox
+            for bbox, kinds in tile_kinds.items()
+        }
         for fut in as_completed(futures):
             exc = fut.exception()
             if exc:
-                kind, bbox = futures[fut]
-                print(f"[_fetch_all_kinds_parallel] worker exception for {kind}: {exc}")
+                print(f"[_fetch_all_kinds_parallel] worker exception: {exc}")
 
     return results
 
@@ -208,7 +218,6 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
 
                 bbox = (south, west, north, east)
                 data = []
-                print("Fetching OSM")
                 try:
                     if prefetched_tiles is not None:
                         tile_result = prefetched_tiles.get(bbox)
@@ -217,6 +226,8 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                         resp, from_cache = tile_result
                         if not resp:
                             continue
+                        src = "cache" if from_cache else "Overpass"
+                        print(f"OSM tile ({kind}): loaded from {src} (prefetched)")
                     else:
                         result = fetch_osm_data(bbox, kind, return_cache_status=True)
                         if not result:
@@ -224,6 +235,8 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                         resp, from_cache = result
                         if not resp:
                             continue
+                        src = "cache" if from_cache else "Overpass"
+                        print(f"OSM tile ({kind}): loaded from {src} (on-demand)")
 
                 except Exception as e:
                     show_message_box(f"Something went wrong with fetching OSM data: {e}")

--- a/tests/Resources/München Marathon.gpx
+++ b/tests/Resources/München Marathon.gpx
@@ -1,0 +1,6405 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gpx version="1.1" creator="https://www.komoot.de" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <metadata>
+    <name>München Marathon</name>
+    <author>
+      <link href="https://www.komoot.de">
+        <text>komoot</text>
+        <type>text/html</type>
+      </link>
+    </author>
+  </metadata>
+  <trk>
+    <name>München Marathon</name>
+    <trkseg>
+      <trkpt lat="48.174483" lon="11.548341">
+        <ele>517.682468</ele>
+        <time>2016-10-09T08:15:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174250" lon="11.548422">
+        <ele>517.682468</ele>
+        <time>2016-10-09T08:15:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174094" lon="11.548538">
+        <ele>517.682468</ele>
+        <time>2016-10-09T08:15:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173994" lon="11.548612">
+        <ele>517.682468</ele>
+        <time>2016-10-09T08:15:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173815" lon="11.548955">
+        <ele>517.682468</ele>
+        <time>2016-10-09T08:15:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173352" lon="11.549020">
+        <ele>517.523278</ele>
+        <time>2016-10-09T08:16:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173145" lon="11.549045">
+        <ele>517.436503</ele>
+        <time>2016-10-09T08:16:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172935" lon="11.549006">
+        <ele>517.348084</ele>
+        <time>2016-10-09T08:16:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172575" lon="11.548913">
+        <ele>517.195442</ele>
+        <time>2016-10-09T08:16:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172332" lon="11.548654">
+        <ele>517.070867</ele>
+        <time>2016-10-09T08:16:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172025" lon="11.548099">
+        <ele>517.026623</ele>
+        <time>2016-10-09T08:17:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171776" lon="11.547845">
+        <ele>517.224176</ele>
+        <time>2016-10-09T08:17:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171609" lon="11.547785">
+        <ele>517.336826</ele>
+        <time>2016-10-09T08:17:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171459" lon="11.547755">
+        <ele>517.436095</ele>
+        <time>2016-10-09T08:17:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171319" lon="11.547790">
+        <ele>517.529200</ele>
+        <time>2016-10-09T08:17:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171307" lon="11.547805">
+        <ele>517.539448</ele>
+        <time>2016-10-09T08:17:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171169" lon="11.547979">
+        <ele>517.657725</ele>
+        <time>2016-10-09T08:17:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171089" lon="11.548073">
+        <ele>517.724396</ele>
+        <time>2016-10-09T08:18:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170967" lon="11.548254">
+        <ele>517.836979</ele>
+        <time>2016-10-09T08:18:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170772" lon="11.548611">
+        <ele>518.038858</ele>
+        <time>2016-10-09T08:18:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170623" lon="11.548845">
+        <ele>518.194034</ele>
+        <time>2016-10-09T08:18:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170406" lon="11.549024">
+        <ele>518.388326</ele>
+        <time>2016-10-09T08:18:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170145" lon="11.549225">
+        <ele>518.618502</ele>
+        <time>2016-10-09T08:18:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170044" lon="11.549290">
+        <ele>518.704725</ele>
+        <time>2016-10-09T08:18:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169582" lon="11.549486">
+        <ele>519.081383</ele>
+        <time>2016-10-09T08:19:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169414" lon="11.549579">
+        <ele>519.221871</ele>
+        <time>2016-10-09T08:19:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169405" lon="11.549584">
+        <ele>519.229400</ele>
+        <time>2016-10-09T08:19:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169229" lon="11.549694">
+        <ele>519.378984</ele>
+        <time>2016-10-09T08:19:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169158" lon="11.549761">
+        <ele>519.444795</ele>
+        <time>2016-10-09T08:19:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168664" lon="11.550178">
+        <ele>519.085244</ele>
+        <time>2016-10-09T08:20:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168598" lon="11.550216">
+        <ele>519.019405</ele>
+        <time>2016-10-09T08:20:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168575" lon="11.550224">
+        <ele>518.997418</ele>
+        <time>2016-10-09T08:20:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168523" lon="11.550236">
+        <ele>518.948422</ele>
+        <time>2016-10-09T08:20:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168377" lon="11.550267">
+        <ele>518.811101</ele>
+        <time>2016-10-09T08:20:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168252" lon="11.550281">
+        <ele>518.694370</ele>
+        <time>2016-10-09T08:20:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168064" lon="11.550292">
+        <ele>518.519160</ele>
+        <time>2016-10-09T08:20:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167978" lon="11.550292">
+        <ele>518.439071</ele>
+        <time>2016-10-09T08:20:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167970" lon="11.550206">
+        <ele>518.385139</ele>
+        <time>2016-10-09T08:20:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167970" lon="11.550070">
+        <ele>518.300670</ele>
+        <time>2016-10-09T08:20:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167984" lon="11.550037">
+        <ele>518.276378</ele>
+        <time>2016-10-09T08:20:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168113" lon="11.549733">
+        <ele>518.052586</ele>
+        <time>2016-10-09T08:20:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168498" lon="11.549234">
+        <ele>517.847192</ele>
+        <time>2016-10-09T08:21:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168753" lon="11.549090">
+        <ele>517.847580</ele>
+        <time>2016-10-09T08:21:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168810" lon="11.549106">
+        <ele>517.847663</ele>
+        <time>2016-10-09T08:21:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168851" lon="11.549193">
+        <ele>517.847764</ele>
+        <time>2016-10-09T08:21:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168933" lon="11.549365">
+        <ele>517.847965</ele>
+        <time>2016-10-09T08:21:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168684" lon="11.549541">
+        <ele>517.848357</ele>
+        <time>2016-10-09T08:21:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168669" lon="11.549558">
+        <ele>517.848384</ele>
+        <time>2016-10-09T08:21:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168418" lon="11.549854">
+        <ele>517.848839</ele>
+        <time>2016-10-09T08:21:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168244" lon="11.550414">
+        <ele>517.792510</ele>
+        <time>2016-10-09T08:22:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168224" lon="11.550677">
+        <ele>517.617235</ele>
+        <time>2016-10-09T08:22:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168324" lon="11.552020">
+        <ele>516.722439</ele>
+        <time>2016-10-09T08:22:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168375" lon="11.552701">
+        <ele>516.268680</ele>
+        <time>2016-10-09T08:23:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168348" lon="11.553182">
+        <ele>515.895517</ele>
+        <time>2016-10-09T08:23:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168344" lon="11.553248">
+        <ele>515.831127</ele>
+        <time>2016-10-09T08:23:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168219" lon="11.553731">
+        <ele>515.327748</ele>
+        <time>2016-10-09T08:23:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168129" lon="11.553911">
+        <ele>515.109169</ele>
+        <time>2016-10-09T08:23:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167875" lon="11.554321">
+        <ele>514.565467</ele>
+        <time>2016-10-09T08:24:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167839" lon="11.554274">
+        <ele>514.495926</ele>
+        <time>2016-10-09T08:24:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167763" lon="11.554227">
+        <ele>514.376161</ele>
+        <time>2016-10-09T08:24:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167689" lon="11.554345">
+        <ele>514.218788</ele>
+        <time>2016-10-09T08:24:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167428" lon="11.553999">
+        <ele>513.711256</ele>
+        <time>2016-10-09T08:24:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167094" lon="11.553665">
+        <ele>513.550393</ele>
+        <time>2016-10-09T08:24:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166468" lon="11.553255">
+        <ele>513.886450</ele>
+        <time>2016-10-09T08:25:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165856" lon="11.553037">
+        <ele>514.195900</ele>
+        <time>2016-10-09T08:25:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165660" lon="11.553004">
+        <ele>514.292927</ele>
+        <time>2016-10-09T08:25:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165306" lon="11.552944">
+        <ele>514.403891</ele>
+        <time>2016-10-09T08:26:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165061" lon="11.552924">
+        <ele>514.469161</ele>
+        <time>2016-10-09T08:26:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164922" lon="11.552922">
+        <ele>514.506139</ele>
+        <time>2016-10-09T08:26:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163323" lon="11.552890">
+        <ele>514.930652</ele>
+        <time>2016-10-09T08:27:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163212" lon="11.552887">
+        <ele>514.959976</ele>
+        <time>2016-10-09T08:27:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162363" lon="11.552861">
+        <ele>515.184271</ele>
+        <time>2016-10-09T08:28:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162358" lon="11.552760">
+        <ele>515.202114</ele>
+        <time>2016-10-09T08:28:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162242" lon="11.552718">
+        <ele>515.233635</ele>
+        <time>2016-10-09T08:28:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161682" lon="11.552695">
+        <ele>515.504315</ele>
+        <time>2016-10-09T08:28:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161679" lon="11.552844">
+        <ele>515.562849</ele>
+        <time>2016-10-09T08:28:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161646" lon="11.552844">
+        <ele>515.582276</ele>
+        <time>2016-10-09T08:28:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161512" lon="11.552843">
+        <ele>515.661160</ele>
+        <time>2016-10-09T08:28:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161466" lon="11.552864">
+        <ele>515.689467</ele>
+        <time>2016-10-09T08:28:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161452" lon="11.552878">
+        <ele>515.699374</ele>
+        <time>2016-10-09T08:28:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161437" lon="11.552893">
+        <ele>515.709988</ele>
+        <time>2016-10-09T08:28:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161409" lon="11.552921">
+        <ele>515.729802</ele>
+        <time>2016-10-09T08:28:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161347" lon="11.552979">
+        <ele>515.772823</ele>
+        <time>2016-10-09T08:28:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161293" lon="11.553032">
+        <ele>515.810818</ele>
+        <time>2016-10-09T08:28:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161291" lon="11.552928">
+        <ele>515.851673</ele>
+        <time>2016-10-09T08:28:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161270" lon="11.552948">
+        <ele>515.866319</ele>
+        <time>2016-10-09T08:29:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161291" lon="11.552928">
+        <ele>515.880965</ele>
+        <time>2016-10-09T08:29:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161293" lon="11.553032">
+        <ele>515.921820</ele>
+        <time>2016-10-09T08:29:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161295" lon="11.553189">
+        <ele>515.983480</ele>
+        <time>2016-10-09T08:29:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161297" lon="11.553364">
+        <ele>516.052208</ele>
+        <time>2016-10-09T08:29:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161298" lon="11.553406">
+        <ele>516.068710</ele>
+        <time>2016-10-09T08:29:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161280" lon="11.555320">
+        <ele>516.774408</ele>
+        <time>2016-10-09T08:30:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161270" lon="11.556576">
+        <ele>517.220402</ele>
+        <time>2016-10-09T08:30:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161264" lon="11.556915">
+        <ele>517.379264</ele>
+        <time>2016-10-09T08:30:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161264" lon="11.556959">
+        <ele>517.408914</ele>
+        <time>2016-10-09T08:30:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161262" lon="11.557074">
+        <ele>517.486437</ele>
+        <time>2016-10-09T08:30:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161258" lon="11.557456">
+        <ele>517.743891</ele>
+        <time>2016-10-09T08:31:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161234" lon="11.558027">
+        <ele>518.129439</ele>
+        <time>2016-10-09T08:31:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161233" lon="11.558060">
+        <ele>518.151700</ele>
+        <time>2016-10-09T08:31:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161226" lon="11.558190">
+        <ele>518.239589</ele>
+        <time>2016-10-09T08:31:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161074" lon="11.558266">
+        <ele>518.401464</ele>
+        <time>2016-10-09T08:31:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160983" lon="11.558333">
+        <ele>518.503886</ele>
+        <time>2016-10-09T08:31:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160942" lon="11.558392">
+        <ele>518.561301</ele>
+        <time>2016-10-09T08:31:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160805" lon="11.558787">
+        <ele>518.861318</ele>
+        <time>2016-10-09T08:31:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160465" lon="11.559813">
+        <ele>519.115876</ele>
+        <time>2016-10-09T08:32:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160259" lon="11.560433">
+        <ele>519.116591</ele>
+        <time>2016-10-09T08:32:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160243" lon="11.560479">
+        <ele>519.116644</ele>
+        <time>2016-10-09T08:32:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160118" lon="11.560863">
+        <ele>519.117085</ele>
+        <time>2016-10-09T08:33:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159965" lon="11.561331">
+        <ele>519.117623</ele>
+        <time>2016-10-09T08:33:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159916" lon="11.561476">
+        <ele>519.117791</ele>
+        <time>2016-10-09T08:33:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159896" lon="11.561581">
+        <ele>519.114686</ele>
+        <time>2016-10-09T08:33:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159743" lon="11.562854">
+        <ele>519.004724</ele>
+        <time>2016-10-09T08:33:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159729" lon="11.562972">
+        <ele>518.994535</ele>
+        <time>2016-10-09T08:34:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159724" lon="11.563000">
+        <ele>518.992071</ele>
+        <time>2016-10-09T08:34:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159706" lon="11.563127">
+        <ele>518.981034</ele>
+        <time>2016-10-09T08:34:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159700" lon="11.563168">
+        <ele>518.977466</ele>
+        <time>2016-10-09T08:34:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159499" lon="11.564922">
+        <ele>519.125976</ele>
+        <time>2016-10-09T08:34:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159491" lon="11.564999">
+        <ele>519.151145</ele>
+        <time>2016-10-09T08:34:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159482" lon="11.565059">
+        <ele>519.171007</ele>
+        <time>2016-10-09T08:34:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159333" lon="11.566047">
+        <ele>519.498158</ele>
+        <time>2016-10-09T08:35:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159261" lon="11.566528">
+        <ele>519.657371</ele>
+        <time>2016-10-09T08:35:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159249" lon="11.566610">
+        <ele>519.684485</ele>
+        <time>2016-10-09T08:35:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159234" lon="11.566694">
+        <ele>519.712570</ele>
+        <time>2016-10-09T08:35:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159133" lon="11.567279">
+        <ele>519.689502</ele>
+        <time>2016-10-09T08:36:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159012" lon="11.567978">
+        <ele>519.579372</ele>
+        <time>2016-10-09T08:36:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158839" lon="11.568947">
+        <ele>519.426396</ele>
+        <time>2016-10-09T08:36:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158812" lon="11.569085">
+        <ele>519.404464</ele>
+        <time>2016-10-09T08:36:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158770" lon="11.569223">
+        <ele>519.381332</ele>
+        <time>2016-10-09T08:36:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158750" lon="11.569295">
+        <ele>519.369438</ele>
+        <time>2016-10-09T08:37:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158644" lon="11.569502">
+        <ele>519.283474</ele>
+        <time>2016-10-09T08:37:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158179" lon="11.571251">
+        <ele>518.285833</ele>
+        <time>2016-10-09T08:37:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158201" lon="11.571420">
+        <ele>518.194595</ele>
+        <time>2016-10-09T08:38:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158109" lon="11.571789">
+        <ele>517.985861</ele>
+        <time>2016-10-09T08:38:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157859" lon="11.572729">
+        <ele>517.532183</ele>
+        <time>2016-10-09T08:38:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157793" lon="11.573013">
+        <ele>517.400813</ele>
+        <time>2016-10-09T08:38:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157634" lon="11.573935">
+        <ele>516.984825</ele>
+        <time>2016-10-09T08:39:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157622" lon="11.574028">
+        <ele>516.943448</ele>
+        <time>2016-10-09T08:39:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157617" lon="11.574149">
+        <ele>516.890491</ele>
+        <time>2016-10-09T08:39:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157590" lon="11.574304">
+        <ele>516.820513</ele>
+        <time>2016-10-09T08:39:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157553" lon="11.574603">
+        <ele>516.774643</ele>
+        <time>2016-10-09T08:39:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157559" lon="11.574870">
+        <ele>516.845453</ele>
+        <time>2016-10-09T08:39:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157567" lon="11.574980">
+        <ele>516.874782</ele>
+        <time>2016-10-09T08:39:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157569" lon="11.575003">
+        <ele>516.880930</ele>
+        <time>2016-10-09T08:39:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157570" lon="11.575025">
+        <ele>516.886775</ele>
+        <time>2016-10-09T08:39:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157576" lon="11.575103">
+        <ele>516.907586</ele>
+        <time>2016-10-09T08:39:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157607" lon="11.575528">
+        <ele>517.020906</ele>
+        <time>2016-10-09T08:39:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157611" lon="11.575639">
+        <ele>517.050370</ele>
+        <time>2016-10-09T08:40:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157605" lon="11.575710">
+        <ele>517.069340</ele>
+        <time>2016-10-09T08:40:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157586" lon="11.575838">
+        <ele>517.104097</ele>
+        <time>2016-10-09T08:40:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157687" lon="11.577508">
+        <ele>517.637052</ele>
+        <time>2016-10-09T08:40:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157702" lon="11.577768">
+        <ele>517.772696</ele>
+        <time>2016-10-09T08:41:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157735" lon="11.578677">
+        <ele>518.245864</ele>
+        <time>2016-10-09T08:41:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157738" lon="11.579288">
+        <ele>518.563451</ele>
+        <time>2016-10-09T08:41:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157720" lon="11.579873">
+        <ele>518.849341</ele>
+        <time>2016-10-09T08:42:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157814" lon="11.579886">
+        <ele>518.785910</ele>
+        <time>2016-10-09T08:42:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157900" lon="11.579904">
+        <ele>518.727561</ele>
+        <time>2016-10-09T08:42:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157884" lon="11.580223">
+        <ele>518.584167</ele>
+        <time>2016-10-09T08:42:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157877" lon="11.580372">
+        <ele>518.517213</ele>
+        <time>2016-10-09T08:42:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157793" lon="11.581552">
+        <ele>517.985280</ele>
+        <time>2016-10-09T08:42:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157713" lon="11.582607">
+        <ele>517.546516</ele>
+        <time>2016-10-09T08:43:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157632" lon="11.582694">
+        <ele>517.497346</ele>
+        <time>2016-10-09T08:43:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157625" lon="11.582742">
+        <ele>517.481172</ele>
+        <time>2016-10-09T08:43:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157407" lon="11.583723">
+        <ele>517.140804</ele>
+        <time>2016-10-09T08:43:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157344" lon="11.583961">
+        <ele>517.056517</ele>
+        <time>2016-10-09T08:44:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157283" lon="11.584229">
+        <ele>516.963304</ele>
+        <time>2016-10-09T08:44:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157216" lon="11.584199">
+        <ele>516.928799</ele>
+        <time>2016-10-09T08:44:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157136" lon="11.584185">
+        <ele>516.889054</ele>
+        <time>2016-10-09T08:44:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157122" lon="11.584178">
+        <ele>516.881772</ele>
+        <time>2016-10-09T08:44:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157111" lon="11.584229">
+        <ele>516.864128</ele>
+        <time>2016-10-09T08:44:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157084" lon="11.584216">
+        <ele>516.850134</ele>
+        <time>2016-10-09T08:44:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157076" lon="11.584212">
+        <ele>516.845973</ele>
+        <time>2016-10-09T08:44:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157078" lon="11.584199">
+        <ele>516.841581</ele>
+        <time>2016-10-09T08:44:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156642" lon="11.583994">
+        <ele>516.954971</ele>
+        <time>2016-10-09T08:44:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156043" lon="11.583713">
+        <ele>517.365810</ele>
+        <time>2016-10-09T08:45:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156033" lon="11.583760">
+        <ele>517.387352</ele>
+        <time>2016-10-09T08:45:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155938" lon="11.583716">
+        <ele>517.452436</ele>
+        <time>2016-10-09T08:45:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155853" lon="11.583696">
+        <ele>517.508756</ele>
+        <time>2016-10-09T08:45:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155786" lon="11.583667">
+        <ele>517.554404</ele>
+        <time>2016-10-09T08:45:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155809" lon="11.583552">
+        <ele>517.606829</ele>
+        <time>2016-10-09T08:45:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155828" lon="11.583454">
+        <ele>517.651393</ele>
+        <time>2016-10-09T08:45:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155832" lon="11.583434">
+        <ele>517.660511</ele>
+        <time>2016-10-09T08:45:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155618" lon="11.583332">
+        <ele>517.807499</ele>
+        <time>2016-10-09T08:45:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155524" lon="11.583287">
+        <ele>517.872091</ele>
+        <time>2016-10-09T08:45:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155497" lon="11.583409">
+        <ele>517.928220</ele>
+        <time>2016-10-09T08:45:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155267" lon="11.583301">
+        <ele>517.954628</ele>
+        <time>2016-10-09T08:45:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155050" lon="11.583200">
+        <ele>517.970356</ele>
+        <time>2016-10-09T08:46:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154973" lon="11.583164">
+        <ele>517.975939</ele>
+        <time>2016-10-09T08:46:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154742" lon="11.583057">
+        <ele>517.992675</ele>
+        <time>2016-10-09T08:46:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154230" lon="11.582814">
+        <ele>518.029849</ele>
+        <time>2016-10-09T08:46:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154120" lon="11.582762">
+        <ele>518.037832</ele>
+        <time>2016-10-09T08:46:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154109" lon="11.582822">
+        <ele>518.040706</ele>
+        <time>2016-10-09T08:46:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153390" lon="11.582507">
+        <ele>517.958555</ele>
+        <time>2016-10-09T08:47:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153147" lon="11.582401">
+        <ele>517.895020</ele>
+        <time>2016-10-09T08:47:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153091" lon="11.582281">
+        <ele>517.870492</ele>
+        <time>2016-10-09T08:47:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153065" lon="11.582225">
+        <ele>517.859066</ele>
+        <time>2016-10-09T08:47:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153025" lon="11.582180">
+        <ele>517.846510</ele>
+        <time>2016-10-09T08:47:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152971" lon="11.582118">
+        <ele>517.829433</ele>
+        <time>2016-10-09T08:47:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152597" lon="11.581915">
+        <ele>517.729575</ele>
+        <time>2016-10-09T08:47:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152498" lon="11.581861">
+        <ele>517.703126</ele>
+        <time>2016-10-09T08:47:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152367" lon="11.581790">
+        <ele>517.668155</ele>
+        <time>2016-10-09T08:48:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152291" lon="11.581761">
+        <ele>517.648467</ele>
+        <time>2016-10-09T08:48:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152235" lon="11.581735">
+        <ele>517.633749</ele>
+        <time>2016-10-09T08:48:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152186" lon="11.581756">
+        <ele>517.620955</ele>
+        <time>2016-10-09T08:48:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151508" lon="11.581453">
+        <ele>517.431439</ele>
+        <time>2016-10-09T08:48:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151419" lon="11.581484">
+        <ele>517.406882</ele>
+        <time>2016-10-09T08:48:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151356" lon="11.581467">
+        <ele>517.389678</ele>
+        <time>2016-10-09T08:48:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151233" lon="11.581414">
+        <ele>517.355283</ele>
+        <time>2016-10-09T08:48:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151130" lon="11.581369">
+        <ele>517.326449</ele>
+        <time>2016-10-09T08:48:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151104" lon="11.581370">
+        <ele>517.319459</ele>
+        <time>2016-10-09T08:48:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151060" lon="11.581360">
+        <ele>517.307498</ele>
+        <time>2016-10-09T08:48:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150660" lon="11.581173">
+        <ele>517.194888</ele>
+        <time>2016-10-09T08:49:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150571" lon="11.581132">
+        <ele>517.169864</ele>
+        <time>2016-10-09T08:49:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150159" lon="11.580940">
+        <ele>517.433838</ele>
+        <time>2016-10-09T08:49:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149860" lon="11.580807">
+        <ele>517.776100</ele>
+        <time>2016-10-09T08:49:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149715" lon="11.580737">
+        <ele>517.943271</ele>
+        <time>2016-10-09T08:49:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149381" lon="11.580576">
+        <ele>518.328287</ele>
+        <time>2016-10-09T08:50:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149320" lon="11.580547">
+        <ele>518.398514</ele>
+        <time>2016-10-09T08:50:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149192" lon="11.580486">
+        <ele>518.545909</ele>
+        <time>2016-10-09T08:50:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149103" lon="11.580443">
+        <ele>518.648525</ele>
+        <time>2016-10-09T08:50:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149023" lon="11.580405">
+        <ele>518.740619</ele>
+        <time>2016-10-09T08:50:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148929" lon="11.580361">
+        <ele>518.848686</ele>
+        <time>2016-10-09T08:50:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148377" lon="11.580107">
+        <ele>519.269529</ele>
+        <time>2016-10-09T08:50:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147591" lon="11.579740">
+        <ele>519.666853</ele>
+        <time>2016-10-09T08:51:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147524" lon="11.579709">
+        <ele>519.700694</ele>
+        <time>2016-10-09T08:51:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146944" lon="11.579440">
+        <ele>519.956943</ele>
+        <time>2016-10-09T08:51:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146869" lon="11.579396">
+        <ele>519.934186</ele>
+        <time>2016-10-09T08:52:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146912" lon="11.579230">
+        <ele>519.900615</ele>
+        <time>2016-10-09T08:52:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147061" lon="11.578682">
+        <ele>519.789053</ele>
+        <time>2016-10-09T08:52:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147079" lon="11.578617">
+        <ele>519.775786</ele>
+        <time>2016-10-09T08:52:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147269" lon="11.577919">
+        <ele>519.633665</ele>
+        <time>2016-10-09T08:52:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147320" lon="11.577731">
+        <ele>519.595405</ele>
+        <time>2016-10-09T08:52:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147328" lon="11.577701">
+        <ele>519.589314</ele>
+        <time>2016-10-09T08:52:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147372" lon="11.577541">
+        <ele>519.556688</ele>
+        <time>2016-10-09T08:52:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147415" lon="11.577382">
+        <ele>519.524344</ele>
+        <time>2016-10-09T08:53:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147436" lon="11.577309">
+        <ele>519.509357</ele>
+        <time>2016-10-09T08:53:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147446" lon="11.577276">
+        <ele>519.502524</ele>
+        <time>2016-10-09T08:53:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147615" lon="11.576701">
+        <ele>519.458786</ele>
+        <time>2016-10-09T08:53:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147671" lon="11.576736">
+        <ele>519.458015</ele>
+        <time>2016-10-09T08:53:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147706" lon="11.576616">
+        <ele>519.456904</ele>
+        <time>2016-10-09T08:53:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147692" lon="11.576608">
+        <ele>519.456714</ele>
+        <time>2016-10-09T08:53:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147755" lon="11.576385">
+        <ele>519.454659</ele>
+        <time>2016-10-09T08:53:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147692" lon="11.576608">
+        <ele>519.452605</ele>
+        <time>2016-10-09T08:53:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147706" lon="11.576616">
+        <ele>519.452415</ele>
+        <time>2016-10-09T08:53:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147882" lon="11.576001">
+        <ele>519.446739</ele>
+        <time>2016-10-09T08:54:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148237" lon="11.574742">
+        <ele>519.338991</ele>
+        <time>2016-10-09T08:54:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148265" lon="11.574642">
+        <ele>519.317478</ele>
+        <time>2016-10-09T08:54:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148288" lon="11.574561">
+        <ele>519.300015</ele>
+        <time>2016-10-09T08:54:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148341" lon="11.574372">
+        <ele>519.259346</ele>
+        <time>2016-10-09T08:54:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148419" lon="11.574094">
+        <ele>519.199521</ele>
+        <time>2016-10-09T08:54:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148467" lon="11.573920">
+        <ele>519.162171</ele>
+        <time>2016-10-09T08:55:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148539" lon="11.573662">
+        <ele>519.106695</ele>
+        <time>2016-10-09T08:55:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148636" lon="11.573317">
+        <ele>519.032429</ele>
+        <time>2016-10-09T08:55:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148823" lon="11.572646">
+        <ele>518.878597</ele>
+        <time>2016-10-09T08:55:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148991" lon="11.572048">
+        <ele>518.675127</ele>
+        <time>2016-10-09T08:55:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148996" lon="11.572033">
+        <ele>518.669869</ele>
+        <time>2016-10-09T08:55:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149007" lon="11.571994">
+        <ele>518.656591</ele>
+        <time>2016-10-09T08:55:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149013" lon="11.571971">
+        <ele>518.648847</ele>
+        <time>2016-10-09T08:56:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149020" lon="11.571949">
+        <ele>518.641204</ele>
+        <time>2016-10-09T08:56:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149051" lon="11.571838">
+        <ele>518.603470</ele>
+        <time>2016-10-09T08:56:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149128" lon="11.571564">
+        <ele>518.510237</ele>
+        <time>2016-10-09T08:56:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149124" lon="11.571550">
+        <ele>518.505462</ele>
+        <time>2016-10-09T08:56:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149180" lon="11.571352">
+        <ele>518.438024</ele>
+        <time>2016-10-09T08:56:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149190" lon="11.571345">
+        <ele>518.432837</ele>
+        <time>2016-10-09T08:56:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149349" lon="11.570793">
+        <ele>518.244296</ele>
+        <time>2016-10-09T08:56:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149610" lon="11.569876">
+        <ele>518.324750</ele>
+        <time>2016-10-09T08:57:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149689" lon="11.569598">
+        <ele>518.521808</ele>
+        <time>2016-10-09T08:57:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149733" lon="11.569447">
+        <ele>518.629266</ele>
+        <time>2016-10-09T08:57:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149689" lon="11.569351">
+        <ele>518.705222</ele>
+        <time>2016-10-09T08:57:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149745" lon="11.569151">
+        <ele>518.846673</ele>
+        <time>2016-10-09T08:57:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149802" lon="11.568947">
+        <ele>518.990907</ele>
+        <time>2016-10-09T08:57:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149857" lon="11.568755">
+        <ele>519.127174</ele>
+        <time>2016-10-09T08:57:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149879" lon="11.568675">
+        <ele>519.183604</ele>
+        <time>2016-10-09T08:57:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149919" lon="11.568538">
+        <ele>519.281129</ele>
+        <time>2016-10-09T08:57:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150005" lon="11.568232">
+        <ele>519.497670</ele>
+        <time>2016-10-09T08:57:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150155" lon="11.567721">
+        <ele>519.854429</ele>
+        <time>2016-10-09T08:58:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150192" lon="11.567593">
+        <ele>519.930384</ele>
+        <time>2016-10-09T08:58:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150205" lon="11.567549">
+        <ele>519.956586</ele>
+        <time>2016-10-09T08:58:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150410" lon="11.566798">
+        <ele>520.398402</ele>
+        <time>2016-10-09T08:58:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149926" lon="11.566484">
+        <ele>520.828815</ele>
+        <time>2016-10-09T08:59:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149265" lon="11.566036">
+        <ele>521.234092</ele>
+        <time>2016-10-09T08:59:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148335" lon="11.565418">
+        <ele>520.920316</ele>
+        <time>2016-10-09T09:00:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148255" lon="11.565366">
+        <ele>520.893421</ele>
+        <time>2016-10-09T09:00:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148005" lon="11.565211">
+        <ele>520.809975</ele>
+        <time>2016-10-09T09:00:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147941" lon="11.565171">
+        <ele>520.788587</ele>
+        <time>2016-10-09T09:00:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147608" lon="11.564965">
+        <ele>520.685463</ele>
+        <time>2016-10-09T09:00:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147365" lon="11.564815">
+        <ele>520.616607</ele>
+        <time>2016-10-09T09:00:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147209" lon="11.564719">
+        <ele>520.572423</ele>
+        <time>2016-10-09T09:01:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147095" lon="11.564648">
+        <ele>520.540079</ele>
+        <time>2016-10-09T09:01:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147095" lon="11.564648">
+        <ele>520.540079</ele>
+        <time>2016-10-09T09:01:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146898" lon="11.564517">
+        <ele>520.483612</ele>
+        <time>2016-10-09T09:01:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146776" lon="11.564436">
+        <ele>520.448651</ele>
+        <time>2016-10-09T09:01:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146597" lon="11.564316">
+        <ele>520.397274</ele>
+        <time>2016-10-09T09:01:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146477" lon="11.564216">
+        <ele>520.361301</ele>
+        <time>2016-10-09T09:01:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146389" lon="11.564125">
+        <ele>520.333289</ele>
+        <time>2016-10-09T09:01:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146391" lon="11.564194">
+        <ele>520.321215</ele>
+        <time>2016-10-09T09:01:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146392" lon="11.564254">
+        <ele>520.310723</ele>
+        <time>2016-10-09T09:01:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146310" lon="11.564579">
+        <ele>520.251983</ele>
+        <time>2016-10-09T09:01:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146112" lon="11.564752">
+        <ele>520.204840</ele>
+        <time>2016-10-09T09:02:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146059" lon="11.564761">
+        <ele>520.193868</ele>
+        <time>2016-10-09T09:02:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146028" lon="11.564782">
+        <ele>520.186870</ele>
+        <time>2016-10-09T09:02:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145929" lon="11.564875">
+        <ele>520.162837</ele>
+        <time>2016-10-09T09:02:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145862" lon="11.564994">
+        <ele>520.141467</ele>
+        <time>2016-10-09T09:02:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145774" lon="11.565309">
+        <ele>520.094598</ele>
+        <time>2016-10-09T09:02:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145633" lon="11.565816">
+        <ele>520.019211</ele>
+        <time>2016-10-09T09:02:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145439" lon="11.566508">
+        <ele>519.916193</ele>
+        <time>2016-10-09T09:03:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145412" lon="11.566603">
+        <ele>519.902021</ele>
+        <time>2016-10-09T09:03:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145390" lon="11.566683">
+        <ele>519.890145</ele>
+        <time>2016-10-09T09:03:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145265" lon="11.567123">
+        <ele>520.060085</ele>
+        <time>2016-10-09T09:03:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145199" lon="11.567354">
+        <ele>520.150948</ele>
+        <time>2016-10-09T09:03:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145076" lon="11.567794">
+        <ele>520.323446</ele>
+        <time>2016-10-09T09:03:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144880" lon="11.568489">
+        <ele>520.596275</ele>
+        <time>2016-10-09T09:04:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144942" lon="11.568538">
+        <ele>520.634259</ele>
+        <time>2016-10-09T09:04:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145127" lon="11.568848">
+        <ele>520.784644</ele>
+        <time>2016-10-09T09:04:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145169" lon="11.569258">
+        <ele>520.946811</ele>
+        <time>2016-10-09T09:04:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145155" lon="11.569361">
+        <ele>520.991376</ele>
+        <time>2016-10-09T09:04:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145140" lon="11.569428">
+        <ele>521.021338</ele>
+        <time>2016-10-09T09:04:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145133" lon="11.569454">
+        <ele>521.033224</ele>
+        <time>2016-10-09T09:04:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145126" lon="11.569476">
+        <ele>521.043558</ele>
+        <time>2016-10-09T09:04:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145103" lon="11.569541">
+        <ele>521.074751</ele>
+        <time>2016-10-09T09:04:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145061" lon="11.569630">
+        <ele>521.120967</ele>
+        <time>2016-10-09T09:04:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145011" lon="11.569708">
+        <ele>521.166824</ele>
+        <time>2016-10-09T09:04:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144949" lon="11.569780">
+        <ele>521.216661</ele>
+        <time>2016-10-09T09:04:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144778" lon="11.569845">
+        <ele>521.328754</ele>
+        <time>2016-10-09T09:04:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144649" lon="11.569895">
+        <ele>521.413416</ele>
+        <time>2016-10-09T09:04:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144571" lon="11.569877">
+        <ele>521.463561</ele>
+        <time>2016-10-09T09:05:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144497" lon="11.569841">
+        <ele>521.512996</ele>
+        <time>2016-10-09T09:05:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144431" lon="11.569792">
+        <ele>521.559795</ele>
+        <time>2016-10-09T09:05:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144275" lon="11.569568">
+        <ele>521.697070</ele>
+        <time>2016-10-09T09:05:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144239" lon="11.569472">
+        <ele>521.743758</ele>
+        <time>2016-10-09T09:05:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144211" lon="11.569359">
+        <ele>521.794864</ele>
+        <time>2016-10-09T09:05:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144229" lon="11.568894">
+        <ele>521.992342</ele>
+        <time>2016-10-09T09:05:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144236" lon="11.568861">
+        <ele>522.007030</ele>
+        <time>2016-10-09T09:05:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143719" lon="11.568533">
+        <ele>522.382493</ele>
+        <time>2016-10-09T09:06:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143677" lon="11.568506">
+        <ele>522.413056</ele>
+        <time>2016-10-09T09:06:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143257" lon="11.568240">
+        <ele>522.717994</ele>
+        <time>2016-10-09T09:06:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143075" lon="11.568124">
+        <ele>522.850262</ele>
+        <time>2016-10-09T09:06:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142750" lon="11.567921">
+        <ele>523.085737</ele>
+        <time>2016-10-09T09:06:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142755" lon="11.567902">
+        <ele>523.094852</ele>
+        <time>2016-10-09T09:06:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142779" lon="11.567813">
+        <ele>523.137689</ele>
+        <time>2016-10-09T09:06:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142715" lon="11.567774">
+        <ele>523.183894</ele>
+        <time>2016-10-09T09:06:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143100" lon="11.566456">
+        <ele>522.735510</ele>
+        <time>2016-10-09T09:07:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143405" lon="11.565412">
+        <ele>522.344066</ele>
+        <time>2016-10-09T09:08:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143448" lon="11.565439">
+        <ele>522.320068</ele>
+        <time>2016-10-09T09:08:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144079" lon="11.565845">
+        <ele>521.354219</ele>
+        <time>2016-10-09T09:08:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144416" lon="11.566062">
+        <ele>520.801084</ele>
+        <time>2016-10-09T09:08:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144809" lon="11.566314">
+        <ele>520.156455</ele>
+        <time>2016-10-09T09:09:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144947" lon="11.566403">
+        <ele>519.929893</ele>
+        <time>2016-10-09T09:09:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144966" lon="11.566415">
+        <ele>519.898800</ele>
+        <time>2016-10-09T09:09:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145325" lon="11.566644">
+        <ele>519.516203</ele>
+        <time>2016-10-09T09:09:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145390" lon="11.566683">
+        <ele>519.493838</ele>
+        <time>2016-10-09T09:09:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145454" lon="11.566724">
+        <ele>519.471606</ele>
+        <time>2016-10-09T09:09:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145976" lon="11.567061">
+        <ele>519.290059</ele>
+        <time>2016-10-09T09:09:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146363" lon="11.567311">
+        <ele>519.155450</ele>
+        <time>2016-10-09T09:10:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146572" lon="11.567446">
+        <ele>519.082756</ele>
+        <time>2016-10-09T09:10:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146667" lon="11.567508">
+        <ele>519.049659</ele>
+        <time>2016-10-09T09:10:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146827" lon="11.567611">
+        <ele>519.000127</ele>
+        <time>2016-10-09T09:10:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147220" lon="11.567864">
+        <ele>519.145645</ele>
+        <time>2016-10-09T09:10:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147522" lon="11.568059">
+        <ele>519.257520</ele>
+        <time>2016-10-09T09:11:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147547" lon="11.567976">
+        <ele>519.278192</ele>
+        <time>2016-10-09T09:11:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147604" lon="11.568012">
+        <ele>519.299236</ele>
+        <time>2016-10-09T09:11:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147756" lon="11.568112">
+        <ele>519.355712</ele>
+        <time>2016-10-09T09:11:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148250" lon="11.568428">
+        <ele>519.538447</ele>
+        <time>2016-10-09T09:11:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148646" lon="11.568681">
+        <ele>519.487150</ele>
+        <time>2016-10-09T09:11:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148688" lon="11.568709">
+        <ele>519.462089</ele>
+        <time>2016-10-09T09:11:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148822" lon="11.568795">
+        <ele>519.382617</ele>
+        <time>2016-10-09T09:12:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148929" lon="11.568863">
+        <ele>519.319253</ele>
+        <time>2016-10-09T09:12:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149032" lon="11.568930">
+        <ele>519.258037</ele>
+        <time>2016-10-09T09:12:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149543" lon="11.569261">
+        <ele>518.954537</ele>
+        <time>2016-10-09T09:12:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149651" lon="11.569328">
+        <ele>518.890811</ele>
+        <time>2016-10-09T09:12:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149689" lon="11.569351">
+        <ele>518.868468</ele>
+        <time>2016-10-09T09:12:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149733" lon="11.569447">
+        <ele>518.826102</ele>
+        <time>2016-10-09T09:12:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149689" lon="11.569598">
+        <ele>518.766166</ele>
+        <time>2016-10-09T09:12:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149349" lon="11.570793">
+        <ele>518.673837</ele>
+        <time>2016-10-09T09:13:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149190" lon="11.571345">
+        <ele>518.703592</ele>
+        <time>2016-10-09T09:13:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149180" lon="11.571352">
+        <ele>518.704411</ele>
+        <time>2016-10-09T09:13:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149124" lon="11.571550">
+        <ele>518.715054</ele>
+        <time>2016-10-09T09:13:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149128" lon="11.571564">
+        <ele>518.715807</ele>
+        <time>2016-10-09T09:13:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149051" lon="11.571838">
+        <ele>518.730521</ele>
+        <time>2016-10-09T09:13:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149020" lon="11.571949">
+        <ele>518.736477</ele>
+        <time>2016-10-09T09:13:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149013" lon="11.571971">
+        <ele>518.737683</ele>
+        <time>2016-10-09T09:13:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149007" lon="11.571994">
+        <ele>518.738905</ele>
+        <time>2016-10-09T09:14:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148996" lon="11.572033">
+        <ele>518.741001</ele>
+        <time>2016-10-09T09:14:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148991" lon="11.572048">
+        <ele>518.741830</ele>
+        <time>2016-10-09T09:14:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148861" lon="11.572513">
+        <ele>518.791830</ele>
+        <time>2016-10-09T09:14:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148823" lon="11.572646">
+        <ele>518.834400</ele>
+        <time>2016-10-09T09:14:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148636" lon="11.573317">
+        <ele>519.048364</ele>
+        <time>2016-10-09T09:14:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148539" lon="11.573662">
+        <ele>519.158521</ele>
+        <time>2016-10-09T09:14:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148467" lon="11.573920">
+        <ele>519.240808</ele>
+        <time>2016-10-09T09:14:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148419" lon="11.574094">
+        <ele>519.296209</ele>
+        <time>2016-10-09T09:15:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148341" lon="11.574372">
+        <ele>519.384945</ele>
+        <time>2016-10-09T09:15:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148288" lon="11.574561">
+        <ele>519.445269</ele>
+        <time>2016-10-09T09:15:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148265" lon="11.574642">
+        <ele>519.471171</ele>
+        <time>2016-10-09T09:15:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148237" lon="11.574742">
+        <ele>519.503081</ele>
+        <time>2016-10-09T09:15:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147882" lon="11.576001">
+        <ele>519.525605</ele>
+        <time>2016-10-09T09:16:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147706" lon="11.576616">
+        <ele>519.509127</ele>
+        <time>2016-10-09T09:16:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147671" lon="11.576736">
+        <ele>519.505902</ele>
+        <time>2016-10-09T09:16:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147615" lon="11.576701">
+        <ele>519.503663</ele>
+        <time>2016-10-09T09:16:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147446" lon="11.577276">
+        <ele>519.489920</ele>
+        <time>2016-10-09T09:16:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147436" lon="11.577309">
+        <ele>519.493424</ele>
+        <time>2016-10-09T09:16:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147415" lon="11.577382">
+        <ele>519.501108</ele>
+        <time>2016-10-09T09:16:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147372" lon="11.577541">
+        <ele>519.517693</ele>
+        <time>2016-10-09T09:16:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147328" lon="11.577701">
+        <ele>519.534422</ele>
+        <time>2016-10-09T09:16:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147320" lon="11.577731">
+        <ele>519.537545</ele>
+        <time>2016-10-09T09:16:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147269" lon="11.577919">
+        <ele>519.557163</ele>
+        <time>2016-10-09T09:17:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147079" lon="11.578617">
+        <ele>519.630036</ele>
+        <time>2016-10-09T09:17:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147061" lon="11.578682">
+        <ele>519.636839</ele>
+        <time>2016-10-09T09:17:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146912" lon="11.579230">
+        <ele>519.694043</ele>
+        <time>2016-10-09T09:17:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146869" lon="11.579396">
+        <ele>519.711256</ele>
+        <time>2016-10-09T09:17:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146944" lon="11.579440">
+        <ele>519.722925</ele>
+        <time>2016-10-09T09:17:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146907" lon="11.579593">
+        <ele>519.738657</ele>
+        <time>2016-10-09T09:17:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146876" lon="11.579732">
+        <ele>519.738638</ele>
+        <time>2016-10-09T09:17:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147352" lon="11.579943">
+        <ele>519.534339</ele>
+        <time>2016-10-09T09:18:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147455" lon="11.579989">
+        <ele>519.490105</ele>
+        <time>2016-10-09T09:18:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147719" lon="11.580106">
+        <ele>519.376798</ele>
+        <time>2016-10-09T09:18:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148253" lon="11.580348">
+        <ele>519.147190</ele>
+        <time>2016-10-09T09:18:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148474" lon="11.580449">
+        <ele>519.052097</ele>
+        <time>2016-10-09T09:19:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148867" lon="11.580635">
+        <ele>518.629118</ele>
+        <time>2016-10-09T09:19:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148955" lon="11.580676">
+        <ele>518.515154</ele>
+        <time>2016-10-09T09:19:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149039" lon="11.580716">
+        <ele>518.406156</ele>
+        <time>2016-10-09T09:19:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149173" lon="11.580783">
+        <ele>518.231463</ele>
+        <time>2016-10-09T09:19:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149306" lon="11.580848">
+        <ele>518.058461</ele>
+        <time>2016-10-09T09:19:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149369" lon="11.580879">
+        <ele>517.976459</ele>
+        <time>2016-10-09T09:19:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149486" lon="11.580936">
+        <ele>517.824316</ele>
+        <time>2016-10-09T09:19:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149627" lon="11.581005">
+        <ele>517.640885</ele>
+        <time>2016-10-09T09:19:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150097" lon="11.581245">
+        <ele>517.026839</ele>
+        <time>2016-10-09T09:20:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150510" lon="11.581447">
+        <ele>516.919041</ele>
+        <time>2016-10-09T09:20:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150987" lon="11.581677">
+        <ele>517.201717</ele>
+        <time>2016-10-09T09:20:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151028" lon="11.581711">
+        <ele>517.228151</ele>
+        <time>2016-10-09T09:20:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151151" lon="11.581751">
+        <ele>517.299154</ele>
+        <time>2016-10-09T09:20:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151167" lon="11.581758">
+        <ele>517.308557</ele>
+        <time>2016-10-09T09:20:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151280" lon="11.581794">
+        <ele>517.373729</ele>
+        <time>2016-10-09T09:21:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151328" lon="11.581956">
+        <ele>517.440444</ele>
+        <time>2016-10-09T09:21:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152018" lon="11.582289">
+        <ele>517.878209</ele>
+        <time>2016-10-09T09:21:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152100" lon="11.582336">
+        <ele>517.956184</ele>
+        <time>2016-10-09T09:21:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152189" lon="11.582387">
+        <ele>518.040812</ele>
+        <time>2016-10-09T09:21:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152240" lon="11.582428">
+        <ele>518.092214</ele>
+        <time>2016-10-09T09:21:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152281" lon="11.582457">
+        <ele>518.132481</ele>
+        <time>2016-10-09T09:21:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152751" lon="11.582664">
+        <ele>518.567578</ele>
+        <time>2016-10-09T09:22:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152881" lon="11.582721">
+        <ele>518.687881</ele>
+        <time>2016-10-09T09:22:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153078" lon="11.582781">
+        <ele>518.866430</ele>
+        <time>2016-10-09T09:22:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153124" lon="11.582763">
+        <ele>518.908657</ele>
+        <time>2016-10-09T09:22:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153160" lon="11.582760">
+        <ele>518.940681</ele>
+        <time>2016-10-09T09:22:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153552" lon="11.582941">
+        <ele>519.304996</ele>
+        <time>2016-10-09T09:22:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154149" lon="11.583219">
+        <ele>519.206057</ele>
+        <time>2016-10-09T09:23:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154276" lon="11.583278">
+        <ele>519.157478</ele>
+        <time>2016-10-09T09:23:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155281" lon="11.583757">
+        <ele>518.772171</ele>
+        <time>2016-10-09T09:24:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155379" lon="11.583803">
+        <ele>518.729955</ele>
+        <time>2016-10-09T09:24:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155535" lon="11.583878">
+        <ele>518.612909</ele>
+        <time>2016-10-09T09:24:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155621" lon="11.583919">
+        <ele>518.548434</ele>
+        <time>2016-10-09T09:24:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156759" lon="11.584439">
+        <ele>517.698457</ele>
+        <time>2016-10-09T09:25:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157030" lon="11.584582">
+        <ele>517.493197</ele>
+        <time>2016-10-09T09:25:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157157" lon="11.584638">
+        <ele>517.386747</ele>
+        <time>2016-10-09T09:25:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157177" lon="11.584667">
+        <ele>517.362647</ele>
+        <time>2016-10-09T09:25:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157209" lon="11.584713">
+        <ele>517.324246</ele>
+        <time>2016-10-09T09:25:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157233" lon="11.584725">
+        <ele>517.302333</ele>
+        <time>2016-10-09T09:25:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157176" lon="11.584991">
+        <ele>517.140906</ele>
+        <time>2016-10-09T09:25:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157176" lon="11.585053">
+        <ele>517.105083</ele>
+        <time>2016-10-09T09:25:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156893" lon="11.586301">
+        <ele>516.343477</ele>
+        <time>2016-10-09T09:26:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156865" lon="11.586451">
+        <ele>516.253479</ele>
+        <time>2016-10-09T09:26:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156890" lon="11.586457">
+        <ele>516.231550</ele>
+        <time>2016-10-09T09:26:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156932" lon="11.586499">
+        <ele>516.187821</ele>
+        <time>2016-10-09T09:26:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156944" lon="11.586532">
+        <ele>516.166105</ele>
+        <time>2016-10-09T09:26:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156950" lon="11.586567">
+        <ele>516.145225</ele>
+        <time>2016-10-09T09:26:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156908" lon="11.586687">
+        <ele>516.066927</ele>
+        <time>2016-10-09T09:26:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156886" lon="11.586701">
+        <ele>516.046226</ele>
+        <time>2016-10-09T09:26:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156901" lon="11.586847">
+        <ele>515.960873</ele>
+        <time>2016-10-09T09:26:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156941" lon="11.586907">
+        <ele>515.911862</ele>
+        <time>2016-10-09T09:26:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156943" lon="11.587127">
+        <ele>515.687662</ele>
+        <time>2016-10-09T09:26:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156931" lon="11.587392">
+        <ele>515.401091</ele>
+        <time>2016-10-09T09:26:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156696" lon="11.588911">
+        <ele>513.718719</ele>
+        <time>2016-10-09T09:27:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156675" lon="11.588933">
+        <ele>513.677283</ele>
+        <time>2016-10-09T09:27:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156590" lon="11.589024">
+        <ele>513.508348</ele>
+        <time>2016-10-09T09:27:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156623" lon="11.589032">
+        <ele>513.454283</ele>
+        <time>2016-10-09T09:27:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157422" lon="11.589238">
+        <ele>512.140948</ele>
+        <time>2016-10-09T09:28:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157509" lon="11.589278">
+        <ele>511.993403</ele>
+        <time>2016-10-09T09:28:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157512" lon="11.589444">
+        <ele>511.813792</ele>
+        <time>2016-10-09T09:28:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157807" lon="11.590011">
+        <ele>511.036061</ele>
+        <time>2016-10-09T09:28:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158207" lon="11.590782">
+        <ele>510.048023</ele>
+        <time>2016-10-09T09:28:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158453" lon="11.590961">
+        <ele>509.935169</ele>
+        <time>2016-10-09T09:29:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158716" lon="11.591120">
+        <ele>509.818132</ele>
+        <time>2016-10-09T09:29:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158867" lon="11.591206">
+        <ele>509.751467</ele>
+        <time>2016-10-09T09:29:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158995" lon="11.591279">
+        <ele>509.694947</ele>
+        <time>2016-10-09T09:29:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159336" lon="11.591484">
+        <ele>509.543319</ele>
+        <time>2016-10-09T09:29:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159352" lon="11.591494">
+        <ele>509.536165</ele>
+        <time>2016-10-09T09:29:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159680" lon="11.591697">
+        <ele>509.389714</ele>
+        <time>2016-10-09T09:30:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159907" lon="11.591822">
+        <ele>509.303780</ele>
+        <time>2016-10-09T09:30:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160016" lon="11.591879">
+        <ele>509.273018</ele>
+        <time>2016-10-09T09:30:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160098" lon="11.592054">
+        <ele>509.235005</ele>
+        <time>2016-10-09T09:30:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160140" lon="11.592143">
+        <ele>509.215627</ele>
+        <time>2016-10-09T09:30:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160320" lon="11.592341">
+        <ele>509.156136</ele>
+        <time>2016-10-09T09:30:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160486" lon="11.592432">
+        <ele>509.109037</ele>
+        <time>2016-10-09T09:30:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160733" lon="11.592446">
+        <ele>509.043173</ele>
+        <time>2016-10-09T09:30:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160814" lon="11.592471">
+        <ele>509.021136</ele>
+        <time>2016-10-09T09:30:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160878" lon="11.592501">
+        <ele>509.003268</ele>
+        <time>2016-10-09T09:30:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161257" lon="11.592744">
+        <ele>508.893428</ele>
+        <time>2016-10-09T09:31:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161497" lon="11.592832">
+        <ele>508.806898</ele>
+        <time>2016-10-09T09:31:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161587" lon="11.592856">
+        <ele>508.759818</ele>
+        <time>2016-10-09T09:31:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161789" lon="11.592916">
+        <ele>508.653760</ele>
+        <time>2016-10-09T09:31:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162051" lon="11.592974">
+        <ele>508.517359</ele>
+        <time>2016-10-09T09:31:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162149" lon="11.592971">
+        <ele>508.466876</ele>
+        <time>2016-10-09T09:31:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162573" lon="11.592904">
+        <ele>508.247294</ele>
+        <time>2016-10-09T09:32:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162720" lon="11.592899">
+        <ele>508.171565</ele>
+        <time>2016-10-09T09:32:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162864" lon="11.592904">
+        <ele>508.097381</ele>
+        <time>2016-10-09T09:32:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162926" lon="11.592918">
+        <ele>508.065089</ele>
+        <time>2016-10-09T09:32:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163215" lon="11.593082">
+        <ele>507.932363</ele>
+        <time>2016-10-09T09:32:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163370" lon="11.593205">
+        <ele>507.978570</ele>
+        <time>2016-10-09T09:32:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163450" lon="11.593268">
+        <ele>508.002379</ele>
+        <time>2016-10-09T09:32:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163492" lon="11.593317">
+        <ele>508.016400</ele>
+        <time>2016-10-09T09:32:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163886" lon="11.593776">
+        <ele>508.147866</ele>
+        <time>2016-10-09T09:33:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164086" lon="11.594052">
+        <ele>508.219487</ele>
+        <time>2016-10-09T09:33:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164337" lon="11.594402">
+        <ele>508.309802</ele>
+        <time>2016-10-09T09:33:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164347" lon="11.594412">
+        <ele>508.312969</ele>
+        <time>2016-10-09T09:33:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164459" lon="11.594524">
+        <ele>508.348440</ele>
+        <time>2016-10-09T09:33:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164515" lon="11.594579">
+        <ele>508.366079</ele>
+        <time>2016-10-09T09:33:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164555" lon="11.594617">
+        <ele>508.378555</ele>
+        <time>2016-10-09T09:33:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164663" lon="11.594697">
+        <ele>508.416172</ele>
+        <time>2016-10-09T09:33:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164900" lon="11.594869">
+        <ele>508.516976</ele>
+        <time>2016-10-09T09:34:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165136" lon="11.595021">
+        <ele>508.615310</ele>
+        <time>2016-10-09T09:34:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165368" lon="11.595149">
+        <ele>508.709951</ele>
+        <time>2016-10-09T09:34:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165530" lon="11.595238">
+        <ele>508.776004</ele>
+        <time>2016-10-09T09:34:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166213" lon="11.595638">
+        <ele>509.056723</ele>
+        <time>2016-10-09T09:35:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166235" lon="11.595651">
+        <ele>509.065776</ele>
+        <time>2016-10-09T09:35:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166620" lon="11.595880">
+        <ele>508.767586</ele>
+        <time>2016-10-09T09:35:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166839" lon="11.596040">
+        <ele>508.553121</ele>
+        <time>2016-10-09T09:35:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166844" lon="11.596201">
+        <ele>508.458487</ele>
+        <time>2016-10-09T09:35:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166990" lon="11.596291">
+        <ele>508.319518</ele>
+        <time>2016-10-09T09:35:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166957" lon="11.596332">
+        <ele>508.281789</ele>
+        <time>2016-10-09T09:35:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166613" lon="11.596810">
+        <ele>507.868897</ele>
+        <time>2016-10-09T09:36:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166338" lon="11.597182">
+        <ele>507.542833</ele>
+        <time>2016-10-09T09:36:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166338" lon="11.597182">
+        <ele>507.542833</ele>
+        <time>2016-10-09T09:36:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166040" lon="11.597592">
+        <ele>507.325261</ele>
+        <time>2016-10-09T09:36:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165954" lon="11.597681">
+        <ele>507.273619</ele>
+        <time>2016-10-09T09:36:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165896" lon="11.597741">
+        <ele>507.238795</ele>
+        <time>2016-10-09T09:36:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165845" lon="11.597807">
+        <ele>507.205501</ele>
+        <time>2016-10-09T09:36:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165713" lon="11.597983">
+        <ele>507.118203</ele>
+        <time>2016-10-09T09:36:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165673" lon="11.598037">
+        <ele>507.091603</ele>
+        <time>2016-10-09T09:36:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165341" lon="11.598238">
+        <ele>506.914658</ele>
+        <time>2016-10-09T09:37:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165233" lon="11.598301">
+        <ele>506.857388</ele>
+        <time>2016-10-09T09:37:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165192" lon="11.598329">
+        <ele>506.835123</ele>
+        <time>2016-10-09T09:37:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165116" lon="11.598382">
+        <ele>506.793700</ele>
+        <time>2016-10-09T09:37:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164913" lon="11.598590">
+        <ele>506.672188</ele>
+        <time>2016-10-09T09:37:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164900" lon="11.598609">
+        <ele>506.663216</ele>
+        <time>2016-10-09T09:37:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164834" lon="11.598746">
+        <ele>506.604414</ele>
+        <time>2016-10-09T09:37:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165518" lon="11.599266">
+        <ele>506.033190</ele>
+        <time>2016-10-09T09:38:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165802" lon="11.599515">
+        <ele>505.788141</ele>
+        <time>2016-10-09T09:38:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166105" lon="11.599780">
+        <ele>505.526863</ele>
+        <time>2016-10-09T09:38:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166353" lon="11.599999">
+        <ele>505.312485</ele>
+        <time>2016-10-09T09:38:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166473" lon="11.600103">
+        <ele>505.165406</ele>
+        <time>2016-10-09T09:38:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167046" lon="11.600600">
+        <ele>504.338096</ele>
+        <time>2016-10-09T09:39:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167962" lon="11.601405">
+        <ele>503.026625</ele>
+        <time>2016-10-09T09:39:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168142" lon="11.601563">
+        <ele>503.036929</ele>
+        <time>2016-10-09T09:40:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168652" lon="11.601980">
+        <ele>503.065626</ele>
+        <time>2016-10-09T09:40:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168780" lon="11.602084">
+        <ele>503.072818</ele>
+        <time>2016-10-09T09:40:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168966" lon="11.602234">
+        <ele>503.083251</ele>
+        <time>2016-10-09T09:40:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168930" lon="11.602342">
+        <ele>503.087229</ele>
+        <time>2016-10-09T09:40:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169292" lon="11.602631">
+        <ele>503.107488</ele>
+        <time>2016-10-09T09:41:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169518" lon="11.602809">
+        <ele>503.180555</ele>
+        <time>2016-10-09T09:41:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169648" lon="11.602924">
+        <ele>503.274549</ele>
+        <time>2016-10-09T09:41:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169596" lon="11.603019">
+        <ele>503.325592</ele>
+        <time>2016-10-09T09:41:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169534" lon="11.603123">
+        <ele>503.383525</ele>
+        <time>2016-10-09T09:41:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169088" lon="11.603873">
+        <ele>503.800856</ele>
+        <time>2016-10-09T09:41:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168651" lon="11.604655">
+        <ele>504.224578</ele>
+        <time>2016-10-09T09:42:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168577" lon="11.604793">
+        <ele>504.247277</ele>
+        <time>2016-10-09T09:42:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168366" lon="11.605143">
+        <ele>504.285481</ele>
+        <time>2016-10-09T09:42:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168538" lon="11.605588">
+        <ele>504.327130</ele>
+        <time>2016-10-09T09:42:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168658" lon="11.605877">
+        <ele>504.354697</ele>
+        <time>2016-10-09T09:43:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168800" lon="11.606086">
+        <ele>504.378857</ele>
+        <time>2016-10-09T09:43:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169106" lon="11.606536">
+        <ele>504.430897</ele>
+        <time>2016-10-09T09:43:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169452" lon="11.606659">
+        <ele>504.546977</ele>
+        <time>2016-10-09T09:43:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169637" lon="11.606633">
+        <ele>504.648898</ele>
+        <time>2016-10-09T09:43:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169939" lon="11.606479">
+        <ele>504.823868</ele>
+        <time>2016-10-09T09:44:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170327" lon="11.605961">
+        <ele>505.108828</ele>
+        <time>2016-10-09T09:44:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170528" lon="11.605797">
+        <ele>505.234346</ele>
+        <time>2016-10-09T09:44:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171085" lon="11.605626">
+        <ele>505.478549</ele>
+        <time>2016-10-09T09:45:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171347" lon="11.605676">
+        <ele>505.531187</ele>
+        <time>2016-10-09T09:45:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171571" lon="11.605796">
+        <ele>505.578594</ele>
+        <time>2016-10-09T09:45:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171941" lon="11.606249">
+        <ele>505.673794</ele>
+        <time>2016-10-09T09:45:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172171" lon="11.606722">
+        <ele>505.751599</ele>
+        <time>2016-10-09T09:45:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172178" lon="11.606737">
+        <ele>505.754032</ele>
+        <time>2016-10-09T09:45:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172666" lon="11.607385">
+        <ele>505.574141</ele>
+        <time>2016-10-09T09:46:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172986" lon="11.608018">
+        <ele>505.297350</ele>
+        <time>2016-10-09T09:46:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173220" lon="11.608370">
+        <ele>505.124158</ele>
+        <time>2016-10-09T09:47:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173555" lon="11.608839">
+        <ele>504.884679</ele>
+        <time>2016-10-09T09:47:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173845" lon="11.609387">
+        <ele>504.547275</ele>
+        <time>2016-10-09T09:47:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174031" lon="11.609636">
+        <ele>504.360947</ele>
+        <time>2016-10-09T09:47:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174257" lon="11.609856">
+        <ele>504.159593</ele>
+        <time>2016-10-09T09:47:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174679" lon="11.610111">
+        <ele>503.819594</ele>
+        <time>2016-10-09T09:48:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174810" lon="11.610190">
+        <ele>503.714079</ele>
+        <time>2016-10-09T09:48:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174960" lon="11.610389">
+        <ele>503.564413</ele>
+        <time>2016-10-09T09:48:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175067" lon="11.610499">
+        <ele>503.485476</ele>
+        <time>2016-10-09T09:48:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175164" lon="11.610599">
+        <ele>503.431228</ele>
+        <time>2016-10-09T09:48:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175529" lon="11.610661">
+        <ele>503.261940</ele>
+        <time>2016-10-09T09:48:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175915" lon="11.610609">
+        <ele>503.083334</ele>
+        <time>2016-10-09T09:49:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176360" lon="11.610391">
+        <ele>502.867587</ele>
+        <time>2016-10-09T09:49:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176668" lon="11.610059">
+        <ele>502.692779</ele>
+        <time>2016-10-09T09:49:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176865" lon="11.609997">
+        <ele>502.719939</ele>
+        <time>2016-10-09T09:49:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177065" lon="11.610040">
+        <ele>502.757393</ele>
+        <time>2016-10-09T09:50:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177215" lon="11.610247">
+        <ele>502.795181</ele>
+        <time>2016-10-09T09:50:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177524" lon="11.610672">
+        <ele>502.872905</ele>
+        <time>2016-10-09T09:50:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177818" lon="11.610843">
+        <ele>502.931361</ele>
+        <time>2016-10-09T09:50:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177898" lon="11.610757">
+        <ele>502.949608</ele>
+        <time>2016-10-09T09:50:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177982" lon="11.610969">
+        <ele>502.980091</ele>
+        <time>2016-10-09T09:50:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178183" lon="11.611115">
+        <ele>503.022426</ele>
+        <time>2016-10-09T09:51:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178749" lon="11.611622">
+        <ele>503.189755</ele>
+        <time>2016-10-09T09:51:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179227" lon="11.612258">
+        <ele>503.351940</ele>
+        <time>2016-10-09T09:51:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179423" lon="11.612648">
+        <ele>503.434590</ele>
+        <time>2016-10-09T09:52:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179672" lon="11.613364">
+        <ele>503.473083</ele>
+        <time>2016-10-09T09:52:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179674" lon="11.613371">
+        <ele>503.473051</ele>
+        <time>2016-10-09T09:52:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179799" lon="11.613878">
+        <ele>503.470775</ele>
+        <time>2016-10-09T09:52:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179931" lon="11.614272">
+        <ele>503.468917</ele>
+        <time>2016-10-09T09:53:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179992" lon="11.614652">
+        <ele>503.467271</ele>
+        <time>2016-10-09T09:53:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180050" lon="11.615003">
+        <ele>503.465748</ele>
+        <time>2016-10-09T09:53:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180041" lon="11.615671">
+        <ele>503.429362</ele>
+        <time>2016-10-09T09:53:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180032" lon="11.616336">
+        <ele>503.346311</ele>
+        <time>2016-10-09T09:53:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180207" lon="11.616973">
+        <ele>503.260286</ele>
+        <time>2016-10-09T09:54:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180345" lon="11.617206">
+        <ele>503.221373</ele>
+        <time>2016-10-09T09:54:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180546" lon="11.617364">
+        <ele>503.178877</ele>
+        <time>2016-10-09T09:54:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180985" lon="11.617547">
+        <ele>502.999483</ele>
+        <time>2016-10-09T09:54:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.181305" lon="11.617604">
+        <ele>502.770884</ele>
+        <time>2016-10-09T09:55:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.181733" lon="11.617538">
+        <ele>502.465665</ele>
+        <time>2016-10-09T09:55:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182011" lon="11.617316">
+        <ele>502.242243</ele>
+        <time>2016-10-09T09:55:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182211" lon="11.617068">
+        <ele>502.058153</ele>
+        <time>2016-10-09T09:55:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182334" lon="11.616800">
+        <ele>501.904263</ele>
+        <time>2016-10-09T09:55:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182512" lon="11.616410">
+        <ele>501.702509</ele>
+        <time>2016-10-09T09:56:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182619" lon="11.616211">
+        <ele>501.597034</ele>
+        <time>2016-10-09T09:56:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182689" lon="11.616114">
+        <ele>501.538060</ele>
+        <time>2016-10-09T09:56:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182820" lon="11.616041">
+        <ele>501.451583</ele>
+        <time>2016-10-09T09:56:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182973" lon="11.616037">
+        <ele>501.356893</ele>
+        <time>2016-10-09T09:56:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183302" lon="11.616198">
+        <ele>501.142746</ele>
+        <time>2016-10-09T09:56:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184217" lon="11.617027">
+        <ele>500.572092</ele>
+        <time>2016-10-09T09:57:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184414" lon="11.617311">
+        <ele>500.462743</ele>
+        <time>2016-10-09T09:57:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184528" lon="11.617552">
+        <ele>500.383901</ele>
+        <time>2016-10-09T09:57:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184603" lon="11.617710">
+        <ele>500.332151</ele>
+        <time>2016-10-09T09:57:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184847" lon="11.618652">
+        <ele>500.062510</ele>
+        <time>2016-10-09T09:58:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184945" lon="11.619294">
+        <ele>500.139382</ele>
+        <time>2016-10-09T09:58:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184769" lon="11.619311">
+        <ele>500.204076</ele>
+        <time>2016-10-09T09:58:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.184321" lon="11.619498">
+        <ele>500.374655</ele>
+        <time>2016-10-09T09:59:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183874" lon="11.619684">
+        <ele>500.544817</ele>
+        <time>2016-10-09T09:59:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183813" lon="11.619697">
+        <ele>500.567417</ele>
+        <time>2016-10-09T09:59:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183753" lon="11.619744">
+        <ele>500.592247</ele>
+        <time>2016-10-09T09:59:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183729" lon="11.619753">
+        <ele>500.601322</ele>
+        <time>2016-10-09T09:59:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.183194" lon="11.620132">
+        <ele>501.133027</ele>
+        <time>2016-10-09T09:59:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182897" lon="11.620265">
+        <ele>501.502259</ele>
+        <time>2016-10-09T10:00:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182727" lon="11.620408">
+        <ele>501.734447</ele>
+        <time>2016-10-09T10:00:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182557" lon="11.620551">
+        <ele>501.966635</ele>
+        <time>2016-10-09T10:00:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182321" lon="11.620700">
+        <ele>502.271663</ele>
+        <time>2016-10-09T10:00:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.182028" lon="11.620676">
+        <ele>502.621217</ele>
+        <time>2016-10-09T10:00:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.181448" lon="11.620433">
+        <ele>503.339595</ele>
+        <time>2016-10-09T10:01:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.181299" lon="11.620263">
+        <ele>503.563047</ele>
+        <time>2016-10-09T10:01:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180798" lon="11.619336">
+        <ele>504.512695</ele>
+        <time>2016-10-09T10:01:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180545" lon="11.619018">
+        <ele>504.906692</ele>
+        <time>2016-10-09T10:02:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.180529" lon="11.619005">
+        <ele>504.928412</ele>
+        <time>2016-10-09T10:02:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179662" lon="11.618316">
+        <ele>505.252235</ele>
+        <time>2016-10-09T10:02:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179319" lon="11.618126">
+        <ele>505.361935</ele>
+        <time>2016-10-09T10:03:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.179186" lon="11.618061">
+        <ele>505.403902</ele>
+        <time>2016-10-09T10:03:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178774" lon="11.617761">
+        <ele>505.473904</ele>
+        <time>2016-10-09T10:03:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178651" lon="11.617627">
+        <ele>505.428934</ele>
+        <time>2016-10-09T10:03:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178396" lon="11.617428">
+        <ele>505.343904</ele>
+        <time>2016-10-09T10:03:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.178237" lon="11.617236">
+        <ele>505.283521</ele>
+        <time>2016-10-09T10:03:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177897" lon="11.616826">
+        <ele>505.154469</ele>
+        <time>2016-10-09T10:04:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177623" lon="11.616746">
+        <ele>505.071898</ele>
+        <time>2016-10-09T10:04:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177396" lon="11.616749">
+        <ele>505.004750</ele>
+        <time>2016-10-09T10:04:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177256" lon="11.616708">
+        <ele>504.980423</ele>
+        <time>2016-10-09T10:04:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.177059" lon="11.616650">
+        <ele>505.004082</ele>
+        <time>2016-10-09T10:04:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176774" lon="11.616404">
+        <ele>505.042833</ele>
+        <time>2016-10-09T10:05:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176483" lon="11.616013">
+        <ele>505.088877</ele>
+        <time>2016-10-09T10:05:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176268" lon="11.615596">
+        <ele>505.130299</ele>
+        <time>2016-10-09T10:05:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.176112" lon="11.615264">
+        <ele>505.162215</ele>
+        <time>2016-10-09T10:05:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175855" lon="11.614929">
+        <ele>505.208532</ele>
+        <time>2016-10-09T10:06:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175431" lon="11.614610">
+        <ele>505.287419</ele>
+        <time>2016-10-09T10:06:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.175136" lon="11.614247">
+        <ele>505.350880</ele>
+        <time>2016-10-09T10:06:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174868" lon="11.614015">
+        <ele>505.402341</ele>
+        <time>2016-10-09T10:06:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174705" lon="11.613920">
+        <ele>505.431423</ele>
+        <time>2016-10-09T10:06:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174298" lon="11.613681">
+        <ele>505.471613</ele>
+        <time>2016-10-09T10:07:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.174114" lon="11.613506">
+        <ele>505.441342</ele>
+        <time>2016-10-09T10:07:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173944" lon="11.613237">
+        <ele>505.407008</ele>
+        <time>2016-10-09T10:07:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173796" lon="11.613070">
+        <ele>505.381276</ele>
+        <time>2016-10-09T10:07:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173552" lon="11.612920">
+        <ele>505.344640</ele>
+        <time>2016-10-09T10:07:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173451" lon="11.612917">
+        <ele>505.330606</ele>
+        <time>2016-10-09T10:07:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173354" lon="11.612877">
+        <ele>505.316630</ele>
+        <time>2016-10-09T10:08:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173094" lon="11.612704">
+        <ele>505.277113</ele>
+        <time>2016-10-09T10:08:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172611" lon="11.612394">
+        <ele>505.231104</ele>
+        <time>2016-10-09T10:08:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172075" lon="11.612135">
+        <ele>505.218009</ele>
+        <time>2016-10-09T10:08:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171888" lon="11.611947">
+        <ele>505.212774</ele>
+        <time>2016-10-09T10:09:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171772" lon="11.611770">
+        <ele>505.208925</ele>
+        <time>2016-10-09T10:09:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171582" lon="11.611300">
+        <ele>505.200402</ele>
+        <time>2016-10-09T10:09:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171351" lon="11.611006">
+        <ele>505.194049</ele>
+        <time>2016-10-09T10:09:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170519" lon="11.610343">
+        <ele>505.183396</ele>
+        <time>2016-10-09T10:10:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170238" lon="11.610009">
+        <ele>505.179342</ele>
+        <time>2016-10-09T10:10:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169916" lon="11.609426">
+        <ele>505.181140</ele>
+        <time>2016-10-09T10:10:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169790" lon="11.609198">
+        <ele>505.201753</ele>
+        <time>2016-10-09T10:11:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169346" lon="11.608515">
+        <ele>505.268148</ele>
+        <time>2016-10-09T10:11:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168894" lon="11.607961">
+        <ele>505.329085</ele>
+        <time>2016-10-09T10:11:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168587" lon="11.607696">
+        <ele>505.396334</ele>
+        <time>2016-10-09T10:12:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167941" lon="11.607231">
+        <ele>506.044220</ele>
+        <time>2016-10-09T10:12:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167857" lon="11.607208">
+        <ele>506.121423</ele>
+        <time>2016-10-09T10:12:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167772" lon="11.607154">
+        <ele>506.204887</ele>
+        <time>2016-10-09T10:12:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167721" lon="11.607116">
+        <ele>506.256378</ele>
+        <time>2016-10-09T10:12:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167613" lon="11.607028">
+        <ele>506.367511</ele>
+        <time>2016-10-09T10:12:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167442" lon="11.606757">
+        <ele>506.592473</ele>
+        <time>2016-10-09T10:13:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167158" lon="11.606502">
+        <ele>506.891767</ele>
+        <time>2016-10-09T10:13:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166868" lon="11.606150">
+        <ele>507.189832</ele>
+        <time>2016-10-09T10:13:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166721" lon="11.606043">
+        <ele>507.313473</ele>
+        <time>2016-10-09T10:13:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166411" lon="11.605897">
+        <ele>507.559332</ele>
+        <time>2016-10-09T10:13:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166270" lon="11.605721">
+        <ele>507.698152</ele>
+        <time>2016-10-09T10:14:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166058" lon="11.605191">
+        <ele>508.010034</ele>
+        <time>2016-10-09T10:14:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165462" lon="11.604869">
+        <ele>508.292707</ele>
+        <time>2016-10-09T10:14:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165232" lon="11.604559">
+        <ele>508.198306</ele>
+        <time>2016-10-09T10:14:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165077" lon="11.604416">
+        <ele>508.142755</ele>
+        <time>2016-10-09T10:15:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164722" lon="11.604090">
+        <ele>508.015687</ele>
+        <time>2016-10-09T10:15:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164593" lon="11.603877">
+        <ele>507.957113</ele>
+        <time>2016-10-09T10:15:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164407" lon="11.603354">
+        <ele>507.836446</ele>
+        <time>2016-10-09T10:15:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164044" lon="11.603029">
+        <ele>507.724502</ele>
+        <time>2016-10-09T10:16:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163584" lon="11.602507">
+        <ele>507.580860</ele>
+        <time>2016-10-09T10:16:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163456" lon="11.602456">
+        <ele>507.547884</ele>
+        <time>2016-10-09T10:16:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163140" lon="11.602433">
+        <ele>507.469112</ele>
+        <time>2016-10-09T10:16:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163042" lon="11.602372">
+        <ele>507.442692</ele>
+        <time>2016-10-09T10:16:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162890" lon="11.602276">
+        <ele>507.401625</ele>
+        <time>2016-10-09T10:16:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162595" lon="11.602064">
+        <ele>507.401455</ele>
+        <time>2016-10-09T10:17:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162252" lon="11.601865">
+        <ele>507.540847</ele>
+        <time>2016-10-09T10:17:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161880" lon="11.601476">
+        <ele>507.712744</ele>
+        <time>2016-10-09T10:17:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161779" lon="11.601673">
+        <ele>507.775557</ele>
+        <time>2016-10-09T10:17:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161676" lon="11.601914">
+        <ele>507.847917</ele>
+        <time>2016-10-09T10:18:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161604" lon="11.601989">
+        <ele>507.881145</ele>
+        <time>2016-10-09T10:18:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161429" lon="11.601997">
+        <ele>507.947501</ele>
+        <time>2016-10-09T10:18:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160771" lon="11.601379">
+        <ele>508.054539</ele>
+        <time>2016-10-09T10:18:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160748" lon="11.601348">
+        <ele>508.055694</ele>
+        <time>2016-10-09T10:18:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160719" lon="11.601407">
+        <ele>508.057518</ele>
+        <time>2016-10-09T10:18:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160656" lon="11.601496">
+        <ele>508.060749</ele>
+        <time>2016-10-09T10:18:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160546" lon="11.601593">
+        <ele>508.065512</ele>
+        <time>2016-10-09T10:18:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160390" lon="11.601633">
+        <ele>508.071419</ele>
+        <time>2016-10-09T10:19:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160287" lon="11.601616">
+        <ele>508.075287</ele>
+        <time>2016-10-09T10:19:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160195" lon="11.601525">
+        <ele>508.079400</ele>
+        <time>2016-10-09T10:19:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160083" lon="11.601328">
+        <ele>508.085845</ele>
+        <time>2016-10-09T10:19:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159943" lon="11.601102">
+        <ele>508.093523</ele>
+        <time>2016-10-09T10:19:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159852" lon="11.600913">
+        <ele>508.099327</ele>
+        <time>2016-10-09T10:19:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159740" lon="11.600561">
+        <ele>508.252767</ele>
+        <time>2016-10-09T10:19:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159691" lon="11.600263">
+        <ele>508.400868</ele>
+        <time>2016-10-09T10:19:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159676" lon="11.600151">
+        <ele>508.455991</ele>
+        <time>2016-10-09T10:19:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159662" lon="11.599963">
+        <ele>508.547272</ele>
+        <time>2016-10-09T10:20:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159662" lon="11.599963">
+        <ele>508.547272</ele>
+        <time>2016-10-09T10:20:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159659" lon="11.599816">
+        <ele>508.618239</ele>
+        <time>2016-10-09T10:20:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159682" lon="11.599683">
+        <ele>508.684538</ele>
+        <time>2016-10-09T10:20:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159729" lon="11.599531">
+        <ele>508.765381</ele>
+        <time>2016-10-09T10:20:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159912" lon="11.599326">
+        <ele>508.930638</ele>
+        <time>2016-10-09T10:20:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160027" lon="11.599297">
+        <ele>509.014996</ele>
+        <time>2016-10-09T10:20:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160036" lon="11.599233">
+        <ele>509.046557</ele>
+        <time>2016-10-09T10:20:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159981" lon="11.599136">
+        <ele>509.107988</ele>
+        <time>2016-10-09T10:20:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159914" lon="11.599023">
+        <ele>509.180941</ele>
+        <time>2016-10-09T10:20:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159914" lon="11.599023">
+        <ele>509.180941</ele>
+        <time>2016-10-09T10:20:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159905" lon="11.599006">
+        <ele>509.191414</ele>
+        <time>2016-10-09T10:20:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159773" lon="11.598977">
+        <ele>509.287921</ele>
+        <time>2016-10-09T10:20:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159690" lon="11.599014">
+        <ele>509.350560</ele>
+        <time>2016-10-09T10:20:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159559" lon="11.599039">
+        <ele>509.507350</ele>
+        <time>2016-10-09T10:20:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159463" lon="11.599033">
+        <ele>509.674165</ele>
+        <time>2016-10-09T10:20:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159315" lon="11.598970">
+        <ele>509.941271</ele>
+        <time>2016-10-09T10:21:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159067" lon="11.599039">
+        <ele>510.379186</ele>
+        <time>2016-10-09T10:21:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158989" lon="11.599212">
+        <ele>510.621013</ele>
+        <time>2016-10-09T10:21:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158976" lon="11.599254">
+        <ele>510.674635</ele>
+        <time>2016-10-09T10:21:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158881" lon="11.599419">
+        <ele>510.927060</ele>
+        <time>2016-10-09T10:21:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158573" lon="11.599695">
+        <ele>511.550044</ele>
+        <time>2016-10-09T10:21:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158310" lon="11.599874">
+        <ele>512.051505</ele>
+        <time>2016-10-09T10:21:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157568" lon="11.599785">
+        <ele>512.587573</ele>
+        <time>2016-10-09T10:22:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157418" lon="11.599836">
+        <ele>512.607971</ele>
+        <time>2016-10-09T10:22:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157173" lon="11.599919">
+        <ele>512.641282</ele>
+        <time>2016-10-09T10:22:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157084" lon="11.599902">
+        <ele>512.653181</ele>
+        <time>2016-10-09T10:22:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156998" lon="11.599870">
+        <ele>512.664932</ele>
+        <time>2016-10-09T10:22:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156427" lon="11.600007">
+        <ele>512.741621</ele>
+        <time>2016-10-09T10:23:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156263" lon="11.599949">
+        <ele>512.760594</ele>
+        <time>2016-10-09T10:23:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156060" lon="11.599835">
+        <ele>512.551327</ele>
+        <time>2016-10-09T10:23:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155744" lon="11.599495">
+        <ele>512.175828</ele>
+        <time>2016-10-09T10:23:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155666" lon="11.599411">
+        <ele>512.083113</ele>
+        <time>2016-10-09T10:23:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155278" lon="11.599211">
+        <ele>511.687028</ele>
+        <time>2016-10-09T10:24:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155197" lon="11.599060">
+        <ele>511.562245</ele>
+        <time>2016-10-09T10:24:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155131" lon="11.598877">
+        <ele>511.428273</ele>
+        <time>2016-10-09T10:24:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155100" lon="11.598644">
+        <ele>511.275265</ele>
+        <time>2016-10-09T10:24:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155185" lon="11.598197">
+        <ele>510.990824</ele>
+        <time>2016-10-09T10:24:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155192" lon="11.598139">
+        <ele>510.963887</ele>
+        <time>2016-10-09T10:24:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155229" lon="11.597845">
+        <ele>510.827153</ele>
+        <time>2016-10-09T10:24:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155237" lon="11.597581">
+        <ele>510.706376</ele>
+        <time>2016-10-09T10:24:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155176" lon="11.597325">
+        <ele>510.582140</ele>
+        <time>2016-10-09T10:25:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155112" lon="11.597228">
+        <ele>510.519790</ele>
+        <time>2016-10-09T10:25:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154962" lon="11.597000">
+        <ele>510.373443</ele>
+        <time>2016-10-09T10:25:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154217" lon="11.595980">
+        <ele>509.797766</ele>
+        <time>2016-10-09T10:25:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153719" lon="11.595472">
+        <ele>509.807740</ele>
+        <time>2016-10-09T10:26:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153522" lon="11.595408">
+        <ele>509.811078</ele>
+        <time>2016-10-09T10:26:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153522" lon="11.595408">
+        <ele>509.811078</ele>
+        <time>2016-10-09T10:26:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153374" lon="11.595466">
+        <ele>509.813611</ele>
+        <time>2016-10-09T10:26:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153175" lon="11.595535">
+        <ele>509.816994</ele>
+        <time>2016-10-09T10:26:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152999" lon="11.595455">
+        <ele>509.820039</ele>
+        <time>2016-10-09T10:26:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152674" lon="11.595018">
+        <ele>509.783124</ele>
+        <time>2016-10-09T10:27:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152420" lon="11.594901">
+        <ele>509.708128</ele>
+        <time>2016-10-09T10:27:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152209" lon="11.594852">
+        <ele>509.647865</ele>
+        <time>2016-10-09T10:27:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151935" lon="11.594742">
+        <ele>509.567807</ele>
+        <time>2016-10-09T10:27:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151817" lon="11.594718">
+        <ele>509.534198</ele>
+        <time>2016-10-09T10:27:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151620" lon="11.594676">
+        <ele>509.478038</ele>
+        <time>2016-10-09T10:27:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151576" lon="11.594447">
+        <ele>509.433165</ele>
+        <time>2016-10-09T10:28:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151579" lon="11.594315">
+        <ele>509.408296</ele>
+        <time>2016-10-09T10:28:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151503" lon="11.594353">
+        <ele>509.385684</ele>
+        <time>2016-10-09T10:28:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150822" lon="11.595196">
+        <ele>508.850970</ele>
+        <time>2016-10-09T10:28:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150815" lon="11.595244">
+        <ele>508.827109</ele>
+        <time>2016-10-09T10:28:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150757" lon="11.595378">
+        <ele>508.749541</ele>
+        <time>2016-10-09T10:28:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150713" lon="11.595409">
+        <ele>508.714153</ele>
+        <time>2016-10-09T10:28:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150321" lon="11.596290">
+        <ele>508.199901</ele>
+        <time>2016-10-09T10:29:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150299" lon="11.596337">
+        <ele>508.172019</ele>
+        <time>2016-10-09T10:29:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150242" lon="11.596460">
+        <ele>508.099292</ele>
+        <time>2016-10-09T10:29:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150188" lon="11.596575">
+        <ele>508.030999</ele>
+        <time>2016-10-09T10:29:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150178" lon="11.596595">
+        <ele>508.018862</ele>
+        <time>2016-10-09T10:29:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150133" lon="11.596682">
+        <ele>508.097813</ele>
+        <time>2016-10-09T10:29:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150103" lon="11.596744">
+        <ele>508.176277</ele>
+        <time>2016-10-09T10:29:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150025" lon="11.596917">
+        <ele>508.390188</ele>
+        <time>2016-10-09T10:29:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149820" lon="11.597359">
+        <ele>508.941676</ele>
+        <time>2016-10-09T10:29:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149776" lon="11.597463">
+        <ele>509.067839</ele>
+        <time>2016-10-09T10:29:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149658" lon="11.597744">
+        <ele>509.407997</ele>
+        <time>2016-10-09T10:30:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149636" lon="11.597787">
+        <ele>509.463512</ele>
+        <time>2016-10-09T10:30:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149624" lon="11.597809">
+        <ele>509.492624</ele>
+        <time>2016-10-09T10:30:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149587" lon="11.597848">
+        <ele>509.562082</ele>
+        <time>2016-10-09T10:30:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149538" lon="11.597908">
+        <ele>509.659241</ele>
+        <time>2016-10-09T10:30:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149406" lon="11.598213">
+        <ele>510.031695</ele>
+        <time>2016-10-09T10:30:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148992" lon="11.599147">
+        <ele>511.907790</ele>
+        <time>2016-10-09T10:31:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148969" lon="11.599197">
+        <ele>512.080212</ele>
+        <time>2016-10-09T10:31:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148917" lon="11.599345">
+        <ele>512.555094</ele>
+        <time>2016-10-09T10:31:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148876" lon="11.599558">
+        <ele>513.184478</ele>
+        <time>2016-10-09T10:31:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148869" lon="11.599727">
+        <ele>513.665204</ele>
+        <time>2016-10-09T10:31:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148867" lon="11.599792">
+        <ele>513.849939</ele>
+        <time>2016-10-09T10:31:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148867" lon="11.599884">
+        <ele>514.111133</ele>
+        <time>2016-10-09T10:31:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148865" lon="11.600032">
+        <ele>514.531401</ele>
+        <time>2016-10-09T10:31:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148864" lon="11.600106">
+        <ele>514.741535</ele>
+        <time>2016-10-09T10:31:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148873" lon="11.600274">
+        <ele>515.220033</ele>
+        <time>2016-10-09T10:31:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148879" lon="11.600449">
+        <ele>515.717525</ele>
+        <time>2016-10-09T10:31:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148880" lon="11.600481">
+        <ele>515.808475</ele>
+        <time>2016-10-09T10:31:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148924" lon="11.601517">
+        <ele>518.653412</ele>
+        <time>2016-10-09T10:32:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148998" lon="11.602101">
+        <ele>519.821461</ele>
+        <time>2016-10-09T10:32:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149025" lon="11.602194">
+        <ele>520.020753</ele>
+        <time>2016-10-09T10:32:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149035" lon="11.602238">
+        <ele>520.112090</ele>
+        <time>2016-10-09T10:32:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149108" lon="11.602689">
+        <ele>521.023991</ele>
+        <time>2016-10-09T10:33:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149200" lon="11.602970">
+        <ele>521.639040</ele>
+        <time>2016-10-09T10:33:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149437" lon="11.603792">
+        <ele>523.398590</ele>
+        <time>2016-10-09T10:33:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149648" lon="11.604589">
+        <ele>524.330104</ele>
+        <time>2016-10-09T10:34:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149869" lon="11.605369">
+        <ele>525.074760</ele>
+        <time>2016-10-09T10:34:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150021" lon="11.605902">
+        <ele>525.584114</ele>
+        <time>2016-10-09T10:34:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150376" lon="11.606734">
+        <ele>526.161370</ele>
+        <time>2016-10-09T10:35:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150832" lon="11.607576">
+        <ele>526.350110</ele>
+        <time>2016-10-09T10:35:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150906" lon="11.607791">
+        <ele>526.392214</ele>
+        <time>2016-10-09T10:35:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150968" lon="11.608027">
+        <ele>526.436356</ele>
+        <time>2016-10-09T10:35:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151160" lon="11.608223">
+        <ele>526.496953</ele>
+        <time>2016-10-09T10:36:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151362" lon="11.608532">
+        <ele>526.525711</ele>
+        <time>2016-10-09T10:36:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151369" lon="11.608540">
+        <ele>526.520061</ele>
+        <time>2016-10-09T10:36:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151708" lon="11.608953">
+        <ele>526.239687</ele>
+        <time>2016-10-09T10:36:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152046" lon="11.609342">
+        <ele>525.966189</ele>
+        <time>2016-10-09T10:36:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152281" lon="11.609633">
+        <ele>525.770554</ele>
+        <time>2016-10-09T10:37:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152478" lon="11.609960">
+        <ele>525.581901</ele>
+        <time>2016-10-09T10:37:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152806" lon="11.610541">
+        <ele>525.226009</ele>
+        <time>2016-10-09T10:37:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153781" lon="11.611333">
+        <ele>524.370371</ele>
+        <time>2016-10-09T10:38:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153886" lon="11.611419">
+        <ele>524.278051</ele>
+        <time>2016-10-09T10:38:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153942" lon="11.611465">
+        <ele>524.228781</ele>
+        <time>2016-10-09T10:38:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153982" lon="11.611507">
+        <ele>524.191100</ele>
+        <time>2016-10-09T10:38:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154345" lon="11.611909">
+        <ele>523.930147</ele>
+        <time>2016-10-09T10:38:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154978" lon="11.612746">
+        <ele>523.605945</ele>
+        <time>2016-10-09T10:39:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155250" lon="11.613092">
+        <ele>523.468926</ele>
+        <time>2016-10-09T10:39:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155301" lon="11.613141">
+        <ele>523.445659</ele>
+        <time>2016-10-09T10:39:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155899" lon="11.613703">
+        <ele>523.153891</ele>
+        <time>2016-10-09T10:40:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155962" lon="11.613763">
+        <ele>523.121303</ele>
+        <time>2016-10-09T10:40:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156073" lon="11.613867">
+        <ele>523.064154</ele>
+        <time>2016-10-09T10:40:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156979" lon="11.614654">
+        <ele>522.606987</ele>
+        <time>2016-10-09T10:40:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157207" lon="11.614855">
+        <ele>522.531486</ele>
+        <time>2016-10-09T10:41:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157367" lon="11.615016">
+        <ele>522.515946</ele>
+        <time>2016-10-09T10:41:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157846" lon="11.615430">
+        <ele>522.471357</ele>
+        <time>2016-10-09T10:41:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158580" lon="11.616074">
+        <ele>522.402771</ele>
+        <time>2016-10-09T10:42:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158733" lon="11.616211">
+        <ele>522.430542</ele>
+        <time>2016-10-09T10:42:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158965" lon="11.616414">
+        <ele>522.537545</ele>
+        <time>2016-10-09T10:42:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159083" lon="11.616517">
+        <ele>522.591936</ele>
+        <time>2016-10-09T10:42:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159138" lon="11.616566">
+        <ele>522.617421</ele>
+        <time>2016-10-09T10:42:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159541" lon="11.616937">
+        <ele>522.805800</ele>
+        <time>2016-10-09T10:43:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160502" lon="11.617784">
+        <ele>522.686603</ele>
+        <time>2016-10-09T10:44:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161249" lon="11.618453">
+        <ele>521.617532</ele>
+        <time>2016-10-09T10:44:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161865" lon="11.619065">
+        <ele>520.640760</ele>
+        <time>2016-10-09T10:45:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161988" lon="11.619251">
+        <ele>520.349358</ele>
+        <time>2016-10-09T10:45:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162069" lon="11.619478">
+        <ele>520.062935</ele>
+        <time>2016-10-09T10:45:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162158" lon="11.619721">
+        <ele>519.754504</ele>
+        <time>2016-10-09T10:45:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162599" lon="11.620408">
+        <ele>518.693710</ele>
+        <time>2016-10-09T10:46:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163108" lon="11.621009">
+        <ele>517.941935</ele>
+        <time>2016-10-09T10:46:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163465" lon="11.621318">
+        <ele>518.036885</ele>
+        <time>2016-10-09T10:46:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164389" lon="11.621841">
+        <ele>518.264379</ele>
+        <time>2016-10-09T10:47:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164474" lon="11.621879">
+        <ele>518.284809</ele>
+        <time>2016-10-09T10:47:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164532" lon="11.621907">
+        <ele>518.298844</ele>
+        <time>2016-10-09T10:47:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164750" lon="11.622018">
+        <ele>518.366592</ele>
+        <time>2016-10-09T10:47:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165681" lon="11.622861">
+        <ele>518.720810</ele>
+        <time>2016-10-09T10:48:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165887" lon="11.623031">
+        <ele>518.797392</ele>
+        <time>2016-10-09T10:48:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165861" lon="11.623107">
+        <ele>518.815946</ele>
+        <time>2016-10-09T10:48:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165866" lon="11.623111">
+        <ele>518.817792</ele>
+        <time>2016-10-09T10:48:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166064" lon="11.623305">
+        <ele>518.894825</ele>
+        <time>2016-10-09T10:48:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166516" lon="11.623721">
+        <ele>518.731113</ele>
+        <time>2016-10-09T10:49:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166728" lon="11.623871">
+        <ele>518.652209</ele>
+        <time>2016-10-09T10:49:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166845" lon="11.623927">
+        <ele>518.610870</ele>
+        <time>2016-10-09T10:49:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166724" lon="11.624270">
+        <ele>518.523762</ele>
+        <time>2016-10-09T10:49:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166714" lon="11.624296">
+        <ele>518.517024</ele>
+        <time>2016-10-09T10:49:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166604" lon="11.624648">
+        <ele>518.429758</ele>
+        <time>2016-10-09T10:49:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166551" lon="11.624907">
+        <ele>518.368939</ele>
+        <time>2016-10-09T10:50:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166514" lon="11.625217">
+        <ele>518.298240</ele>
+        <time>2016-10-09T10:50:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166511" lon="11.625262">
+        <ele>518.281739</ele>
+        <time>2016-10-09T10:50:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166501" lon="11.625368">
+        <ele>518.239991</ele>
+        <time>2016-10-09T10:50:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166445" lon="11.626370">
+        <ele>517.847875</ele>
+        <time>2016-10-09T10:50:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166386" lon="11.626912">
+        <ele>517.633716</ele>
+        <time>2016-10-09T10:50:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166310" lon="11.627351">
+        <ele>517.456847</ele>
+        <time>2016-10-09T10:51:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166302" lon="11.627391">
+        <ele>517.440562</ele>
+        <time>2016-10-09T10:51:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166265" lon="11.627562">
+        <ele>517.370456</ele>
+        <time>2016-10-09T10:51:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166204" lon="11.627843">
+        <ele>517.255217</ele>
+        <time>2016-10-09T10:51:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165942" lon="11.628984">
+        <ele>517.037270</ele>
+        <time>2016-10-09T10:51:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165794" lon="11.629629">
+        <ele>516.917226</ele>
+        <time>2016-10-09T10:52:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165755" lon="11.629605">
+        <ele>516.906103</ele>
+        <time>2016-10-09T10:52:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165462" lon="11.629437">
+        <ele>516.823330</ele>
+        <time>2016-10-09T10:52:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165332" lon="11.629376">
+        <ele>516.787386</ele>
+        <time>2016-10-09T10:52:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165332" lon="11.629376">
+        <ele>516.787386</ele>
+        <time>2016-10-09T10:52:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165212" lon="11.629322">
+        <ele>516.808296</ele>
+        <time>2016-10-09T10:52:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164957" lon="11.629232">
+        <ele>516.970404</ele>
+        <time>2016-10-09T10:52:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164227" lon="11.629087">
+        <ele>517.426079</ele>
+        <time>2016-10-09T10:53:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164153" lon="11.629082">
+        <ele>517.471917</ele>
+        <time>2016-10-09T10:53:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163917" lon="11.629067">
+        <ele>517.618086</ele>
+        <time>2016-10-09T10:53:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163772" lon="11.629058">
+        <ele>517.707890</ele>
+        <time>2016-10-09T10:53:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163337" lon="11.629036">
+        <ele>517.929794</ele>
+        <time>2016-10-09T10:53:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162756" lon="11.629005">
+        <ele>518.107551</ele>
+        <time>2016-10-09T10:54:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162672" lon="11.629007">
+        <ele>518.133238</ele>
+        <time>2016-10-09T10:54:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162603" lon="11.629009">
+        <ele>518.154339</ele>
+        <time>2016-10-09T10:54:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162581" lon="11.629007">
+        <ele>518.161078</ele>
+        <time>2016-10-09T10:54:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162434" lon="11.628995">
+        <ele>518.206090</ele>
+        <time>2016-10-09T10:54:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162350" lon="11.628988">
+        <ele>518.231814</ele>
+        <time>2016-10-09T10:54:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162226" lon="11.628989">
+        <ele>518.269728</ele>
+        <time>2016-10-09T10:54:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162110" lon="11.628990">
+        <ele>518.305196</ele>
+        <time>2016-10-09T10:54:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162012" lon="11.628990">
+        <ele>518.335161</ele>
+        <time>2016-10-09T10:54:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160562" lon="11.628906">
+        <ele>518.422741</ele>
+        <time>2016-10-09T10:55:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160451" lon="11.628885">
+        <ele>518.421684</ele>
+        <time>2016-10-09T10:55:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160353" lon="11.628864">
+        <ele>518.420749</ele>
+        <time>2016-10-09T10:56:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160286" lon="11.628856">
+        <ele>518.420114</ele>
+        <time>2016-10-09T10:56:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159545" lon="11.628807">
+        <ele>518.616463</ele>
+        <time>2016-10-09T10:56:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159159" lon="11.628779">
+        <ele>518.836776</ele>
+        <time>2016-10-09T10:56:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159054" lon="11.628771">
+        <ele>518.896713</ele>
+        <time>2016-10-09T10:56:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158941" lon="11.628771">
+        <ele>518.961133</ele>
+        <time>2016-10-09T10:57:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158614" lon="11.628777">
+        <ele>519.147567</ele>
+        <time>2016-10-09T10:57:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158310" lon="11.628804">
+        <ele>519.321179</ele>
+        <time>2016-10-09T10:57:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158288" lon="11.628806">
+        <ele>519.333744</ele>
+        <time>2016-10-09T10:57:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158008" lon="11.628836">
+        <ele>519.453536</ele>
+        <time>2016-10-09T10:57:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157760" lon="11.628886">
+        <ele>519.485721</ele>
+        <time>2016-10-09T10:57:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157559" lon="11.628956">
+        <ele>519.512261</ele>
+        <time>2016-10-09T10:57:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156846" lon="11.629219">
+        <ele>519.606701</ele>
+        <time>2016-10-09T10:58:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156631" lon="11.629304">
+        <ele>519.635299</ele>
+        <time>2016-10-09T10:58:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156108" lon="11.629436">
+        <ele>519.853646</ele>
+        <time>2016-10-09T10:59:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155575" lon="11.629497">
+        <ele>520.262348</ele>
+        <time>2016-10-09T10:59:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155280" lon="11.629506">
+        <ele>520.487943</ele>
+        <time>2016-10-09T10:59:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155171" lon="11.629497">
+        <ele>520.571407</ele>
+        <time>2016-10-09T10:59:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154659" lon="11.629487">
+        <ele>520.962900</ele>
+        <time>2016-10-09T11:00:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154594" lon="11.629480">
+        <ele>521.012726</ele>
+        <time>2016-10-09T11:00:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154223" lon="11.629415">
+        <ele>521.482058</ele>
+        <time>2016-10-09T11:00:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154160" lon="11.629395">
+        <ele>521.567486</ele>
+        <time>2016-10-09T11:00:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153760" lon="11.629333">
+        <ele>522.100947</ele>
+        <time>2016-10-09T11:00:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153723" lon="11.629325">
+        <ele>522.150538</ele>
+        <time>2016-10-09T11:00:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153709" lon="11.629316">
+        <ele>522.170746</ele>
+        <time>2016-10-09T11:00:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153678" lon="11.629267">
+        <ele>522.230510</ele>
+        <time>2016-10-09T11:00:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153665" lon="11.629226">
+        <ele>522.270685</ele>
+        <time>2016-10-09T11:00:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153646" lon="11.629223">
+        <ele>522.296030</ele>
+        <time>2016-10-09T11:00:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153594" lon="11.629214">
+        <ele>522.365470</ele>
+        <time>2016-10-09T11:00:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153555" lon="11.629209">
+        <ele>522.417395</ele>
+        <time>2016-10-09T11:00:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153529" lon="11.629205">
+        <ele>522.452068</ele>
+        <time>2016-10-09T11:00:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153513" lon="11.629205">
+        <ele>522.473293</ele>
+        <time>2016-10-09T11:00:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153495" lon="11.629203">
+        <ele>522.497237</ele>
+        <time>2016-10-09T11:00:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153471" lon="11.629201">
+        <ele>522.529124</ele>
+        <time>2016-10-09T11:00:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153412" lon="11.629195">
+        <ele>522.607572</ele>
+        <time>2016-10-09T11:00:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153341" lon="11.629188">
+        <ele>522.701962</ele>
+        <time>2016-10-09T11:01:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153262" lon="11.629213">
+        <ele>522.809072</ele>
+        <time>2016-10-09T11:01:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152934" lon="11.629121">
+        <ele>523.251742</ele>
+        <time>2016-10-09T11:01:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152817" lon="11.629097">
+        <ele>523.408398</ele>
+        <time>2016-10-09T11:01:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152817" lon="11.629097">
+        <ele>523.408398</ele>
+        <time>2016-10-09T11:01:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152701" lon="11.629056">
+        <ele>523.506060</ele>
+        <time>2016-10-09T11:01:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152649" lon="11.629046">
+        <ele>523.543792</ele>
+        <time>2016-10-09T11:01:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152578" lon="11.629034">
+        <ele>523.595215</ele>
+        <time>2016-10-09T11:01:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152400" lon="11.628975">
+        <ele>523.726418</ele>
+        <time>2016-10-09T11:01:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152285" lon="11.628937">
+        <ele>523.811172</ele>
+        <time>2016-10-09T11:01:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152254" lon="11.628926">
+        <ele>523.834100</ele>
+        <time>2016-10-09T11:01:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152197" lon="11.628908">
+        <ele>523.876024</ele>
+        <time>2016-10-09T11:01:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151006" lon="11.628512">
+        <ele>524.748724</ele>
+        <time>2016-10-09T11:02:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149065" lon="11.628412">
+        <ele>525.738885</ele>
+        <time>2016-10-09T11:04:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148640" lon="11.628377">
+        <ele>525.712128</ele>
+        <time>2016-10-09T11:04:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147586" lon="11.628245">
+        <ele>525.645639</ele>
+        <time>2016-10-09T11:05:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147486" lon="11.628217">
+        <ele>525.639244</ele>
+        <time>2016-10-09T11:05:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147382" lon="11.628185">
+        <ele>525.588830</ele>
+        <time>2016-10-09T11:05:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147271" lon="11.628179">
+        <ele>525.513443</ele>
+        <time>2016-10-09T11:05:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146325" lon="11.628004">
+        <ele>524.866504</ele>
+        <time>2016-10-09T11:05:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145966" lon="11.627933">
+        <ele>524.620732</ele>
+        <time>2016-10-09T11:06:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145467" lon="11.627835">
+        <ele>524.377745</ele>
+        <time>2016-10-09T11:06:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144467" lon="11.627641">
+        <ele>524.185476</ele>
+        <time>2016-10-09T11:07:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144346" lon="11.627640">
+        <ele>524.162404</ele>
+        <time>2016-10-09T11:07:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144301" lon="11.627639">
+        <ele>524.153823</ele>
+        <time>2016-10-09T11:07:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143676" lon="11.627632">
+        <ele>524.260548</ele>
+        <time>2016-10-09T11:07:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142961" lon="11.627623">
+        <ele>524.920950</ele>
+        <time>2016-10-09T11:08:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142514" lon="11.627535">
+        <ele>525.337349</ele>
+        <time>2016-10-09T11:08:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142121" lon="11.627315">
+        <ele>525.724824</ele>
+        <time>2016-10-09T11:08:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141686" lon="11.627054">
+        <ele>526.224572</ele>
+        <time>2016-10-09T11:09:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141548" lon="11.626970">
+        <ele>526.383921</ele>
+        <time>2016-10-09T11:09:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140988" lon="11.626854">
+        <ele>526.988718</ele>
+        <time>2016-10-09T11:09:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140185" lon="11.626816">
+        <ele>527.653665</ele>
+        <time>2016-10-09T11:10:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139963" lon="11.626832">
+        <ele>527.647257</ele>
+        <time>2016-10-09T11:10:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139497" lon="11.626866">
+        <ele>527.633807</ele>
+        <time>2016-10-09T11:10:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139453" lon="11.626854">
+        <ele>527.632518</ele>
+        <time>2016-10-09T11:10:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139440" lon="11.626866">
+        <ele>527.632078</ele>
+        <time>2016-10-09T11:10:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139416" lon="11.626870">
+        <ele>527.631381</ele>
+        <time>2016-10-09T11:10:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139404" lon="11.626849">
+        <ele>527.630850</ele>
+        <time>2016-10-09T11:10:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139391" lon="11.626815">
+        <ele>527.630096</ele>
+        <time>2016-10-09T11:10:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139361" lon="11.626014">
+        <ele>527.614662</ele>
+        <time>2016-10-09T11:11:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139340" lon="11.625858">
+        <ele>527.611600</ele>
+        <time>2016-10-09T11:11:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139321" lon="11.625702">
+        <ele>527.608549</ele>
+        <time>2016-10-09T11:11:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139104" lon="11.624739">
+        <ele>527.600594</ele>
+        <time>2016-10-09T11:11:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139059" lon="11.624618">
+        <ele>527.599654</ele>
+        <time>2016-10-09T11:12:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138947" lon="11.624478">
+        <ele>527.598171</ele>
+        <time>2016-10-09T11:12:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138919" lon="11.624551">
+        <ele>527.597599</ele>
+        <time>2016-10-09T11:12:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138810" lon="11.624485">
+        <ele>527.596404</ele>
+        <time>2016-10-09T11:12:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138677" lon="11.624445">
+        <ele>527.595024</ele>
+        <time>2016-10-09T11:12:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138539" lon="11.624435">
+        <ele>527.593619</ele>
+        <time>2016-10-09T11:12:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138311" lon="11.624439">
+        <ele>527.591300</ele>
+        <time>2016-10-09T11:12:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138275" lon="11.624440">
+        <ele>527.590933</ele>
+        <time>2016-10-09T11:12:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138111" lon="11.624443">
+        <ele>527.589265</ele>
+        <time>2016-10-09T11:12:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136894" lon="11.624430">
+        <ele>528.221523</ele>
+        <time>2016-10-09T11:13:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136754" lon="11.624429">
+        <ele>528.298311</ele>
+        <time>2016-10-09T11:13:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136668" lon="11.624427">
+        <ele>528.345485</ele>
+        <time>2016-10-09T11:13:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136369" lon="11.624417">
+        <ele>528.509521</ele>
+        <time>2016-10-09T11:14:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136189" lon="11.624409">
+        <ele>528.539691</ele>
+        <time>2016-10-09T11:14:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136106" lon="11.624405">
+        <ele>528.490996</ele>
+        <time>2016-10-09T11:14:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136050" lon="11.624405">
+        <ele>528.458159</ele>
+        <time>2016-10-09T11:14:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135952" lon="11.624423">
+        <ele>528.400264</ele>
+        <time>2016-10-09T11:14:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135908" lon="11.624446">
+        <ele>528.372938</ele>
+        <time>2016-10-09T11:14:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135847" lon="11.624537">
+        <ele>528.322465</ele>
+        <time>2016-10-09T11:14:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135800" lon="11.624662">
+        <ele>528.266319</ele>
+        <time>2016-10-09T11:14:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135772" lon="11.624789">
+        <ele>528.213978</ele>
+        <time>2016-10-09T11:14:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135762" lon="11.624885">
+        <ele>528.175956</ele>
+        <time>2016-10-09T11:14:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135775" lon="11.625569">
+        <ele>527.908177</ele>
+        <time>2016-10-09T11:14:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135791" lon="11.625912">
+        <ele>527.773624</ele>
+        <time>2016-10-09T11:15:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135833" lon="11.626873">
+        <ele>527.354589</ele>
+        <time>2016-10-09T11:15:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135932" lon="11.628984">
+        <ele>526.244197</ele>
+        <time>2016-10-09T11:16:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135972" lon="11.629793">
+        <ele>526.033737</ele>
+        <time>2016-10-09T11:16:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136007" lon="11.630635">
+        <ele>525.922125</ele>
+        <time>2016-10-09T11:17:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135984" lon="11.630639">
+        <ele>525.917535</ele>
+        <time>2016-10-09T11:17:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135926" lon="11.630646">
+        <ele>525.906000</ele>
+        <time>2016-10-09T11:17:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135886" lon="11.630639">
+        <ele>525.898016</ele>
+        <time>2016-10-09T11:17:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135523" lon="11.632834">
+        <ele>525.799336</ele>
+        <time>2016-10-09T11:18:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135442" lon="11.632986">
+        <ele>525.807797</ele>
+        <time>2016-10-09T11:18:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135333" lon="11.633141">
+        <ele>525.817592</ele>
+        <time>2016-10-09T11:18:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135304" lon="11.633196">
+        <ele>525.820641</ele>
+        <time>2016-10-09T11:18:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135296" lon="11.633208">
+        <ele>525.821379</ele>
+        <time>2016-10-09T11:18:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135091" lon="11.633161">
+        <ele>525.834897</ele>
+        <time>2016-10-09T11:18:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135069" lon="11.633156">
+        <ele>525.836348</ele>
+        <time>2016-10-09T11:18:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134900" lon="11.633117">
+        <ele>525.847493</ele>
+        <time>2016-10-09T11:18:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134796" lon="11.633093">
+        <ele>525.854352</ele>
+        <time>2016-10-09T11:18:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134780" lon="11.633089">
+        <ele>525.855410</ele>
+        <time>2016-10-09T11:18:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134151" lon="11.632944">
+        <ele>525.760188</ele>
+        <time>2016-10-09T11:19:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134141" lon="11.632942">
+        <ele>525.757842</ele>
+        <time>2016-10-09T11:19:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134103" lon="11.632933">
+        <ele>525.748895</ele>
+        <time>2016-10-09T11:19:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133885" lon="11.632883">
+        <ele>525.697609</ele>
+        <time>2016-10-09T11:19:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133841" lon="11.632874">
+        <ele>525.687282</ele>
+        <time>2016-10-09T11:19:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133784" lon="11.632837">
+        <ele>525.672837</ele>
+        <time>2016-10-09T11:19:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133349" lon="11.632646">
+        <ele>525.567425</ele>
+        <time>2016-10-09T11:19:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133358" lon="11.632593">
+        <ele>525.558937</ele>
+        <time>2016-10-09T11:19:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133239" lon="11.632518">
+        <ele>525.528915</ele>
+        <time>2016-10-09T11:19:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133149" lon="11.632470">
+        <ele>525.506700</ele>
+        <time>2016-10-09T11:20:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133093" lon="11.632464">
+        <ele>525.493644</ele>
+        <time>2016-10-09T11:20:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132950" lon="11.632398">
+        <ele>525.458847</ele>
+        <time>2016-10-09T11:20:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132765" lon="11.632337">
+        <ele>525.490699</ele>
+        <time>2016-10-09T11:20:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132582" lon="11.632280">
+        <ele>525.544566</ele>
+        <time>2016-10-09T11:20:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132369" lon="11.632242">
+        <ele>525.606385</ele>
+        <time>2016-10-09T11:20:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131856" lon="11.632152">
+        <ele>525.755239</ele>
+        <time>2016-10-09T11:20:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131688" lon="11.632103">
+        <ele>525.804564</ele>
+        <time>2016-10-09T11:21:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131604" lon="11.632079">
+        <ele>525.829209</ele>
+        <time>2016-10-09T11:21:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131298" lon="11.631993">
+        <ele>525.918934</ele>
+        <time>2016-10-09T11:21:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131166" lon="11.631953">
+        <ele>525.957746</ele>
+        <time>2016-10-09T11:21:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130998" lon="11.631903">
+        <ele>526.153741</ele>
+        <time>2016-10-09T11:21:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130747" lon="11.631767">
+        <ele>526.512235</ele>
+        <time>2016-10-09T11:21:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130696" lon="11.631674">
+        <ele>526.620136</ele>
+        <time>2016-10-09T11:21:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130744" lon="11.631394">
+        <ele>526.879290</ele>
+        <time>2016-10-09T11:21:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130806" lon="11.631030">
+        <ele>527.216056</ele>
+        <time>2016-10-09T11:22:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130845" lon="11.630787">
+        <ele>527.440103</ele>
+        <time>2016-10-09T11:22:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130975" lon="11.629980">
+        <ele>528.184309</ele>
+        <time>2016-10-09T11:22:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131293" lon="11.628331">
+        <ele>528.988064</ele>
+        <time>2016-10-09T11:23:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131371" lon="11.627959">
+        <ele>529.145915</ele>
+        <time>2016-10-09T11:23:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131506" lon="11.627241">
+        <ele>529.447892</ele>
+        <time>2016-10-09T11:24:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131531" lon="11.627111">
+        <ele>529.466669</ele>
+        <time>2016-10-09T11:24:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131659" lon="11.626508">
+        <ele>529.403099</ele>
+        <time>2016-10-09T11:24:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131790" lon="11.625798">
+        <ele>529.329095</ele>
+        <time>2016-10-09T11:24:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131805" lon="11.625721">
+        <ele>529.321036</ele>
+        <time>2016-10-09T11:24:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131835" lon="11.625553">
+        <ele>529.303565</ele>
+        <time>2016-10-09T11:24:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131972" lon="11.624801">
+        <ele>529.225253</ele>
+        <time>2016-10-09T11:25:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132013" lon="11.624597">
+        <ele>529.203849</ele>
+        <time>2016-10-09T11:25:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132029" lon="11.624525">
+        <ele>529.229153</ele>
+        <time>2016-10-09T11:25:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132067" lon="11.624370">
+        <ele>529.292207</ele>
+        <time>2016-10-09T11:25:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132099" lon="11.624236">
+        <ele>529.346553</ele>
+        <time>2016-10-09T11:25:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132136" lon="11.624082">
+        <ele>529.409052</ele>
+        <time>2016-10-09T11:25:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132154" lon="11.624008">
+        <ele>529.439128</ele>
+        <time>2016-10-09T11:25:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132270" lon="11.623522">
+        <ele>529.636218</ele>
+        <time>2016-10-09T11:25:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132319" lon="11.623311">
+        <ele>529.721527</ele>
+        <time>2016-10-09T11:25:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132550" lon="11.622314">
+        <ele>530.124521</ele>
+        <time>2016-10-09T11:26:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132659" lon="11.621746">
+        <ele>530.410764</ele>
+        <time>2016-10-09T11:26:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132720" lon="11.621445">
+        <ele>530.592511</ele>
+        <time>2016-10-09T11:26:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132829" lon="11.620910">
+        <ele>530.915696</ele>
+        <time>2016-10-09T11:27:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132952" lon="11.620187">
+        <ele>531.346774</ele>
+        <time>2016-10-09T11:27:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132991" lon="11.619943">
+        <ele>531.491734</ele>
+        <time>2016-10-09T11:27:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133068" lon="11.619206">
+        <ele>531.904784</ele>
+        <time>2016-10-09T11:27:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133082" lon="11.618995">
+        <ele>532.010827</ele>
+        <time>2016-10-09T11:28:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133106" lon="11.618632">
+        <ele>532.193255</ele>
+        <time>2016-10-09T11:28:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133104" lon="11.618371">
+        <ele>532.323791</ele>
+        <time>2016-10-09T11:28:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133103" lon="11.618331">
+        <ele>532.343810</ele>
+        <time>2016-10-09T11:28:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133087" lon="11.618013">
+        <ele>532.503295</ele>
+        <time>2016-10-09T11:28:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133000" lon="11.618014">
+        <ele>532.568489</ele>
+        <time>2016-10-09T11:28:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132974" lon="11.617986">
+        <ele>532.592482</ele>
+        <time>2016-10-09T11:28:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132727" lon="11.617940">
+        <ele>532.778992</ele>
+        <time>2016-10-09T11:28:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132663" lon="11.617918">
+        <ele>532.828196</ele>
+        <time>2016-10-09T11:28:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132522" lon="11.617852">
+        <ele>532.938888</ele>
+        <time>2016-10-09T11:28:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132395" lon="11.617792">
+        <ele>533.038672</ele>
+        <time>2016-10-09T11:28:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131835" lon="11.617529">
+        <ele>533.257839</ele>
+        <time>2016-10-09T11:29:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131389" lon="11.617322">
+        <ele>533.381667</ele>
+        <time>2016-10-09T11:29:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131389" lon="11.617322">
+        <ele>533.381667</ele>
+        <time>2016-10-09T11:29:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130866" lon="11.617080">
+        <ele>533.526836</ele>
+        <time>2016-10-09T11:30:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131057" lon="11.616000">
+        <ele>533.572722</ele>
+        <time>2016-10-09T11:30:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131069" lon="11.615927">
+        <ele>533.567753</ele>
+        <time>2016-10-09T11:30:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131121" lon="11.615588">
+        <ele>533.544764</ele>
+        <time>2016-10-09T11:30:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131122" lon="11.615501">
+        <ele>533.539013</ele>
+        <time>2016-10-09T11:30:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131156" lon="11.615314">
+        <ele>533.526204</ele>
+        <time>2016-10-09T11:30:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131171" lon="11.615231">
+        <ele>533.520521</ele>
+        <time>2016-10-09T11:30:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131258" lon="11.614748">
+        <ele>533.487457</ele>
+        <time>2016-10-09T11:31:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131332" lon="11.614297">
+        <ele>533.456762</ele>
+        <time>2016-10-09T11:31:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131262" lon="11.614274">
+        <ele>533.449666</ele>
+        <time>2016-10-09T11:31:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131210" lon="11.614256">
+        <ele>533.444381</ele>
+        <time>2016-10-09T11:31:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131185" lon="11.614248">
+        <ele>533.441850</ele>
+        <time>2016-10-09T11:31:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131128" lon="11.614229">
+        <ele>533.436067</ele>
+        <time>2016-10-09T11:31:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131163" lon="11.614015">
+        <ele>533.476884</ele>
+        <time>2016-10-09T11:31:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131210" lon="11.613716">
+        <ele>533.534657</ele>
+        <time>2016-10-09T11:31:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131317" lon="11.613062">
+        <ele>533.661299</ele>
+        <time>2016-10-09T11:32:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131317" lon="11.613062">
+        <ele>533.661299</ele>
+        <time>2016-10-09T11:32:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131361" lon="11.612819">
+        <ele>533.708653</ele>
+        <time>2016-10-09T11:32:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131496" lon="11.612210">
+        <ele>533.829342</ele>
+        <time>2016-10-09T11:32:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131555" lon="11.612036">
+        <ele>533.866048</ele>
+        <time>2016-10-09T11:32:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131518" lon="11.611993">
+        <ele>533.879243</ele>
+        <time>2016-10-09T11:32:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131506" lon="11.611981">
+        <ele>533.883309</ele>
+        <time>2016-10-09T11:32:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130840" lon="11.611321">
+        <ele>533.906157</ele>
+        <time>2016-10-09T11:33:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130370" lon="11.610881">
+        <ele>533.871645</ele>
+        <time>2016-10-09T11:33:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129688" lon="11.610244">
+        <ele>533.761728</ele>
+        <time>2016-10-09T11:34:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129079" lon="11.609645">
+        <ele>533.419251</ele>
+        <time>2016-10-09T11:34:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128660" lon="11.609232">
+        <ele>533.183470</ele>
+        <time>2016-10-09T11:34:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128558" lon="11.609123">
+        <ele>533.124571</ele>
+        <time>2016-10-09T11:35:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128440" lon="11.608975">
+        <ele>533.052226</ele>
+        <time>2016-10-09T11:35:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128415" lon="11.608937">
+        <ele>533.035484</ele>
+        <time>2016-10-09T11:35:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128452" lon="11.608869">
+        <ele>533.007956</ele>
+        <time>2016-10-09T11:35:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128390" lon="11.608780">
+        <ele>532.974352</ele>
+        <time>2016-10-09T11:35:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127917" lon="11.608055">
+        <ele>532.778498</ele>
+        <time>2016-10-09T11:35:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127516" lon="11.607450">
+        <ele>532.613782</ele>
+        <time>2016-10-09T11:36:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127226" lon="11.607021">
+        <ele>532.495825</ele>
+        <time>2016-10-09T11:36:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127130" lon="11.606879">
+        <ele>532.472502</ele>
+        <time>2016-10-09T11:36:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127090" lon="11.606820">
+        <ele>532.488920</ele>
+        <time>2016-10-09T11:36:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126986" lon="11.606666">
+        <ele>532.531688</ele>
+        <time>2016-10-09T11:36:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126952" lon="11.606716">
+        <ele>532.545622</ele>
+        <time>2016-10-09T11:36:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126702" lon="11.606345">
+        <ele>532.648541</ele>
+        <time>2016-10-09T11:36:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126273" lon="11.605695">
+        <ele>532.826996</ele>
+        <time>2016-10-09T11:37:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126239" lon="11.605645">
+        <ele>532.840930</ele>
+        <time>2016-10-09T11:37:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126195" lon="11.605578">
+        <ele>532.859280</ele>
+        <time>2016-10-09T11:37:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125800" lon="11.604985">
+        <ele>533.183008</ele>
+        <time>2016-10-09T11:37:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125480" lon="11.604506">
+        <ele>533.974051</ele>
+        <time>2016-10-09T11:38:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125119" lon="11.603965">
+        <ele>534.866968</ele>
+        <time>2016-10-09T11:38:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124921" lon="11.603664">
+        <ele>535.360254</ele>
+        <time>2016-10-09T11:38:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124864" lon="11.603578">
+        <ele>535.501720</ele>
+        <time>2016-10-09T11:38:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124782" lon="11.603455">
+        <ele>535.704638</ele>
+        <time>2016-10-09T11:38:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124758" lon="11.603421">
+        <ele>535.762400</ele>
+        <time>2016-10-09T11:38:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124734" lon="11.603388">
+        <ele>535.819367</ele>
+        <time>2016-10-09T11:38:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124640" lon="11.603245">
+        <ele>536.053638</ele>
+        <time>2016-10-09T11:39:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124406" lon="11.602895">
+        <ele>536.043584</ele>
+        <time>2016-10-09T11:39:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124379" lon="11.602854">
+        <ele>536.031061</ele>
+        <time>2016-10-09T11:39:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124227" lon="11.602628">
+        <ele>535.961303</ele>
+        <time>2016-10-09T11:39:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124185" lon="11.602565">
+        <ele>535.941943</ele>
+        <time>2016-10-09T11:39:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.123983" lon="11.602262">
+        <ele>535.848829</ele>
+        <time>2016-10-09T11:39:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.123900" lon="11.602142">
+        <ele>535.811256</ele>
+        <time>2016-10-09T11:39:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124340" lon="11.601351">
+        <ele>535.587374</ele>
+        <time>2016-10-09T11:40:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124457" lon="11.601134">
+        <ele>535.424152</ele>
+        <time>2016-10-09T11:40:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124780" lon="11.600505">
+        <ele>534.493720</ele>
+        <time>2016-10-09T11:40:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124836" lon="11.600474">
+        <ele>534.388860</ele>
+        <time>2016-10-09T11:40:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124851" lon="11.600465">
+        <ele>534.360479</ele>
+        <time>2016-10-09T11:40:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.124921" lon="11.600399">
+        <ele>534.215206</ele>
+        <time>2016-10-09T11:40:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125106" lon="11.600078">
+        <ele>533.717991</ele>
+        <time>2016-10-09T11:40:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125197" lon="11.599924">
+        <ele>533.476855</ele>
+        <time>2016-10-09T11:41:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125211" lon="11.599900">
+        <ele>533.439487</ele>
+        <time>2016-10-09T11:41:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125236" lon="11.599857">
+        <ele>533.372631</ele>
+        <time>2016-10-09T11:41:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125283" lon="11.599789">
+        <ele>533.257866</ele>
+        <time>2016-10-09T11:41:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125337" lon="11.599743">
+        <ele>533.148759</ele>
+        <time>2016-10-09T11:41:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125366" lon="11.599628">
+        <ele>533.004630</ele>
+        <time>2016-10-09T11:41:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125380" lon="11.599590">
+        <ele>532.953743</ele>
+        <time>2016-10-09T11:41:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125387" lon="11.599570">
+        <ele>532.927266</ele>
+        <time>2016-10-09T11:41:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125392" lon="11.599556">
+        <ele>532.908651</ele>
+        <time>2016-10-09T11:41:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125399" lon="11.599543">
+        <ele>532.889069</ele>
+        <time>2016-10-09T11:41:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125412" lon="11.599514">
+        <ele>532.848113</ele>
+        <time>2016-10-09T11:41:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125439" lon="11.599466">
+        <ele>532.774520</ele>
+        <time>2016-10-09T11:41:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125420" lon="11.599403">
+        <ele>532.693468</ele>
+        <time>2016-10-09T11:41:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.125428" lon="11.599329">
+        <ele>532.605579</ele>
+        <time>2016-10-09T11:41:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126128" lon="11.598182">
+        <ele>532.754023</ele>
+        <time>2016-10-09T11:42:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126227" lon="11.598022">
+        <ele>532.811806</ele>
+        <time>2016-10-09T11:42:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126546" lon="11.597501">
+        <ele>532.999054</ele>
+        <time>2016-10-09T11:42:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126576" lon="11.597451">
+        <ele>533.016860</ele>
+        <time>2016-10-09T11:42:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.126630" lon="11.597358">
+        <ele>533.049506</ele>
+        <time>2016-10-09T11:42:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127174" lon="11.596442">
+        <ele>533.020171</ele>
+        <time>2016-10-09T11:43:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127894" lon="11.595247">
+        <ele>532.886713</ele>
+        <time>2016-10-09T11:43:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127931" lon="11.595182">
+        <ele>532.875266</ele>
+        <time>2016-10-09T11:43:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.127965" lon="11.595127">
+        <ele>532.851586</ele>
+        <time>2016-10-09T11:43:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128437" lon="11.594362">
+        <ele>532.522507</ele>
+        <time>2016-10-09T11:44:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128525" lon="11.594206">
+        <ele>532.457988</ele>
+        <time>2016-10-09T11:44:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128622" lon="11.594069">
+        <ele>532.394900</ele>
+        <time>2016-10-09T11:44:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128670" lon="11.594114">
+        <ele>532.368103</ele>
+        <time>2016-10-09T11:44:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128688" lon="11.594080">
+        <ele>532.354395</ele>
+        <time>2016-10-09T11:44:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128710" lon="11.594030">
+        <ele>532.335478</ele>
+        <time>2016-10-09T11:44:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128723" lon="11.594003">
+        <ele>532.324961</ele>
+        <time>2016-10-09T11:44:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128738" lon="11.593971">
+        <ele>532.312610</ele>
+        <time>2016-10-09T11:44:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128752" lon="11.593941">
+        <ele>532.301047</ele>
+        <time>2016-10-09T11:44:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128775" lon="11.593892">
+        <ele>532.282124</ele>
+        <time>2016-10-09T11:44:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128792" lon="11.593835">
+        <ele>532.262403</ele>
+        <time>2016-10-09T11:44:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.128875" lon="11.593719">
+        <ele>532.208686</ele>
+        <time>2016-10-09T11:44:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129111" lon="11.593363">
+        <ele>532.050193</ele>
+        <time>2016-10-09T11:45:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129386" lon="11.592951">
+        <ele>532.023056</ele>
+        <time>2016-10-09T11:45:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129581" lon="11.592639">
+        <ele>532.017362</ele>
+        <time>2016-10-09T11:45:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129618" lon="11.592587">
+        <ele>532.016350</ele>
+        <time>2016-10-09T11:45:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129807" lon="11.592315">
+        <ele>532.011120</ele>
+        <time>2016-10-09T11:45:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.129892" lon="11.592192">
+        <ele>532.008761</ele>
+        <time>2016-10-09T11:45:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130039" lon="11.591987">
+        <ele>532.004753</ele>
+        <time>2016-10-09T11:46:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130155" lon="11.591824">
+        <ele>532.001579</ele>
+        <time>2016-10-09T11:46:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130239" lon="11.591706">
+        <ele>531.999281</ele>
+        <time>2016-10-09T11:46:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130378" lon="11.591513">
+        <ele>531.995499</ele>
+        <time>2016-10-09T11:46:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.130989" lon="11.590666">
+        <ele>530.319813</ele>
+        <time>2016-10-09T11:46:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131178" lon="11.590404">
+        <ele>529.753101</ele>
+        <time>2016-10-09T11:47:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131237" lon="11.590321">
+        <ele>529.574978</ele>
+        <time>2016-10-09T11:47:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131608" lon="11.589879">
+        <ele>528.531755</ele>
+        <time>2016-10-09T11:47:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131707" lon="11.589761">
+        <ele>528.253326</ele>
+        <time>2016-10-09T11:47:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131672" lon="11.589654">
+        <ele>528.078286</ele>
+        <time>2016-10-09T11:47:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131630" lon="11.589530">
+        <ele>527.754663</ele>
+        <time>2016-10-09T11:47:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131604" lon="11.589452">
+        <ele>527.531844</ele>
+        <time>2016-10-09T11:47:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131565" lon="11.589334">
+        <ele>527.195326</ele>
+        <time>2016-10-09T11:47:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131572" lon="11.589279">
+        <ele>527.052233</ele>
+        <time>2016-10-09T11:47:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131543" lon="11.589005">
+        <ele>526.343233</ele>
+        <time>2016-10-09T11:47:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131448" lon="11.588140">
+        <ele>524.102860</ele>
+        <time>2016-10-09T11:48:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131436" lon="11.587950">
+        <ele>523.615115</ele>
+        <time>2016-10-09T11:48:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131425" lon="11.587809">
+        <ele>523.252314</ele>
+        <time>2016-10-09T11:48:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131417" lon="11.587739">
+        <ele>523.070814</ele>
+        <time>2016-10-09T11:48:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131422" lon="11.587677">
+        <ele>522.911210</ele>
+        <time>2016-10-09T11:48:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131445" lon="11.587494">
+        <ele>522.435304</ele>
+        <time>2016-10-09T11:48:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131466" lon="11.587381">
+        <ele>522.135529</ele>
+        <time>2016-10-09T11:48:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131531" lon="11.587060">
+        <ele>521.278237</ele>
+        <time>2016-10-09T11:48:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131640" lon="11.586507">
+        <ele>520.563486</ele>
+        <time>2016-10-09T11:48:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131673" lon="11.586401">
+        <ele>520.433410</ele>
+        <time>2016-10-09T11:48:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131677" lon="11.586291">
+        <ele>520.310898</ele>
+        <time>2016-10-09T11:49:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131749" lon="11.585948">
+        <ele>519.911028</ele>
+        <time>2016-10-09T11:49:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131792" lon="11.585841">
+        <ele>519.772128</ele>
+        <time>2016-10-09T11:49:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131840" lon="11.585762">
+        <ele>519.653319</ele>
+        <time>2016-10-09T11:49:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.131877" lon="11.585678">
+        <ele>519.541393</ele>
+        <time>2016-10-09T11:49:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132114" lon="11.585140">
+        <ele>518.824513</ele>
+        <time>2016-10-09T11:49:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132195" lon="11.584939">
+        <ele>518.563397</ele>
+        <time>2016-10-09T11:49:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132243" lon="11.584796">
+        <ele>518.385389</ele>
+        <time>2016-10-09T11:49:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132294" lon="11.584653">
+        <ele>518.205080</ele>
+        <time>2016-10-09T11:49:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132305" lon="11.584537">
+        <ele>518.167423</ele>
+        <time>2016-10-09T11:49:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132664" lon="11.583818">
+        <ele>518.380960</ele>
+        <time>2016-10-09T11:50:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132676" lon="11.583792">
+        <ele>518.388477</ele>
+        <time>2016-10-09T11:50:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132738" lon="11.583662">
+        <ele>518.426474</ele>
+        <time>2016-10-09T11:50:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132854" lon="11.583431">
+        <ele>518.495220</ele>
+        <time>2016-10-09T11:50:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.132935" lon="11.583367">
+        <ele>518.527849</ele>
+        <time>2016-10-09T11:50:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133070" lon="11.583258">
+        <ele>518.582490</ele>
+        <time>2016-10-09T11:50:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133106" lon="11.583224">
+        <ele>518.597653</ele>
+        <time>2016-10-09T11:50:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133176" lon="11.583169">
+        <ele>518.625817</ele>
+        <time>2016-10-09T11:50:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133598" lon="11.582884">
+        <ele>518.790749</ele>
+        <time>2016-10-09T11:51:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133778" lon="11.582758">
+        <ele>518.964532</ele>
+        <time>2016-10-09T11:51:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133816" lon="11.582728">
+        <ele>519.002497</ele>
+        <time>2016-10-09T11:51:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133843" lon="11.582704">
+        <ele>519.030247</ele>
+        <time>2016-10-09T11:51:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133855" lon="11.582694">
+        <ele>519.042384</ele>
+        <time>2016-10-09T11:51:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133768" lon="11.582427">
+        <ele>519.217662</ele>
+        <time>2016-10-09T11:51:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133726" lon="11.582298">
+        <ele>519.302334</ele>
+        <time>2016-10-09T11:51:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133705" lon="11.582223">
+        <ele>519.350314</ele>
+        <time>2016-10-09T11:51:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133690" lon="11.582157">
+        <ele>519.391444</ele>
+        <time>2016-10-09T11:51:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133682" lon="11.582072">
+        <ele>519.442083</ele>
+        <time>2016-10-09T11:51:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133689" lon="11.581858">
+        <ele>519.568477</ele>
+        <time>2016-10-09T11:51:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133699" lon="11.581768">
+        <ele>519.622301</ele>
+        <time>2016-10-09T11:51:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133720" lon="11.581589">
+        <ele>519.729515</ele>
+        <time>2016-10-09T11:51:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133774" lon="11.581158">
+        <ele>519.988212</ele>
+        <time>2016-10-09T11:52:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133832" lon="11.580738">
+        <ele>520.241226</ele>
+        <time>2016-10-09T11:52:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133863" lon="11.580522">
+        <ele>520.371561</ele>
+        <time>2016-10-09T11:52:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133953" lon="11.579897">
+        <ele>520.734578</ele>
+        <time>2016-10-09T11:52:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133964" lon="11.579712">
+        <ele>520.839914</ele>
+        <time>2016-10-09T11:52:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133964" lon="11.579639">
+        <ele>520.881315</ele>
+        <time>2016-10-09T11:52:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.133978" lon="11.579643">
+        <ele>520.893427</ele>
+        <time>2016-10-09T11:52:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134028" lon="11.579640">
+        <ele>520.935950</ele>
+        <time>2016-10-09T11:52:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134218" lon="11.579636">
+        <ele>521.097426</ele>
+        <time>2016-10-09T11:52:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134539" lon="11.579629">
+        <ele>521.370237</ele>
+        <time>2016-10-09T11:53:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134603" lon="11.579622">
+        <ele>521.424768</ele>
+        <time>2016-10-09T11:53:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134689" lon="11.579628">
+        <ele>521.497929</ele>
+        <time>2016-10-09T11:53:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135071" lon="11.579616">
+        <ele>521.822619</ele>
+        <time>2016-10-09T11:53:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135105" lon="11.579269">
+        <ele>521.827417</ele>
+        <time>2016-10-09T11:53:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135105" lon="11.579155">
+        <ele>521.779245</ele>
+        <time>2016-10-09T11:53:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135075" lon="11.578947">
+        <ele>521.689323</ele>
+        <time>2016-10-09T11:53:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135031" lon="11.578722">
+        <ele>521.590248</ele>
+        <time>2016-10-09T11:54:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135013" lon="11.577828">
+        <ele>521.212305</ele>
+        <time>2016-10-09T11:54:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135006" lon="11.577435">
+        <ele>521.046178</ele>
+        <time>2016-10-09T11:54:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134993" lon="11.577403">
+        <ele>521.030348</ele>
+        <time>2016-10-09T11:54:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134992" lon="11.577345">
+        <ele>521.005831</ele>
+        <time>2016-10-09T11:54:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134991" lon="11.577249">
+        <ele>520.965260</ele>
+        <time>2016-10-09T11:54:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134991" lon="11.577176">
+        <ele>520.934413</ele>
+        <time>2016-10-09T11:54:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.134992" lon="11.576844">
+        <ele>520.794121</ele>
+        <time>2016-10-09T11:54:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135282" lon="11.576869">
+        <ele>520.702079</ele>
+        <time>2016-10-09T11:55:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135333" lon="11.576837">
+        <ele>520.687019</ele>
+        <time>2016-10-09T11:55:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135406" lon="11.576690">
+        <ele>520.653711</ele>
+        <time>2016-10-09T11:55:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135500" lon="11.576642">
+        <ele>520.626661</ele>
+        <time>2016-10-09T11:55:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135584" lon="11.576456">
+        <ele>520.585836</ele>
+        <time>2016-10-09T11:55:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135824" lon="11.576234">
+        <ele>520.509011</ele>
+        <time>2016-10-09T11:55:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135853" lon="11.576207">
+        <ele>520.499711</ele>
+        <time>2016-10-09T11:55:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135900" lon="11.576328">
+        <ele>520.474262</ele>
+        <time>2016-10-09T11:55:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.135930" lon="11.576407">
+        <ele>520.457739</ele>
+        <time>2016-10-09T11:55:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136005" lon="11.576548">
+        <ele>520.424963</ele>
+        <time>2016-10-09T11:55:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136165" lon="11.576750">
+        <ele>520.367975</ele>
+        <time>2016-10-09T11:55:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136232" lon="11.576816">
+        <ele>520.346135</ele>
+        <time>2016-10-09T11:55:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136421" lon="11.577012">
+        <ele>520.283528</ele>
+        <time>2016-10-09T11:56:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136427" lon="11.577018">
+        <ele>520.281563</ele>
+        <time>2016-10-09T11:56:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136455" lon="11.577048">
+        <ele>520.316972</ele>
+        <time>2016-10-09T11:56:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136475" lon="11.577004">
+        <ele>520.353700</ele>
+        <time>2016-10-09T11:56:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136517" lon="11.576962">
+        <ele>520.405899</ele>
+        <time>2016-10-09T11:56:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136790" lon="11.576586">
+        <ele>520.789220</ele>
+        <time>2016-10-09T11:56:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136854" lon="11.576373">
+        <ele>520.950374</ele>
+        <time>2016-10-09T11:56:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136913" lon="11.576177">
+        <ele>521.098711</ele>
+        <time>2016-10-09T11:56:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.136935" lon="11.576104">
+        <ele>521.153970</ele>
+        <time>2016-10-09T11:56:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137058" lon="11.576235">
+        <ele>521.309969</ele>
+        <time>2016-10-09T11:56:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137142" lon="11.576323">
+        <ele>521.415923</ele>
+        <time>2016-10-09T11:56:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137166" lon="11.576342">
+        <ele>521.443983</ele>
+        <time>2016-10-09T11:56:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137235" lon="11.576391">
+        <ele>521.522918</ele>
+        <time>2016-10-09T11:56:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137262" lon="11.576413">
+        <ele>521.554689</ele>
+        <time>2016-10-09T11:57:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137757" lon="11.576763">
+        <ele>522.120510</ele>
+        <time>2016-10-09T11:57:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.137980" lon="11.576921">
+        <ele>522.196755</ele>
+        <time>2016-10-09T11:57:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138004" lon="11.576939">
+        <ele>522.203360</ele>
+        <time>2016-10-09T11:57:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138277" lon="11.577059">
+        <ele>522.273375</ele>
+        <time>2016-10-09T11:57:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138614" lon="11.577192">
+        <ele>522.359138</ele>
+        <time>2016-10-09T11:58:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138614" lon="11.577192">
+        <ele>522.359138</ele>
+        <time>2016-10-09T11:58:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138781" lon="11.577246">
+        <ele>522.401182</ele>
+        <time>2016-10-09T11:58:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.138856" lon="11.577271">
+        <ele>522.420091</ele>
+        <time>2016-10-09T11:58:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139489" lon="11.577454">
+        <ele>522.578743</ele>
+        <time>2016-10-09T11:58:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139566" lon="11.577476">
+        <ele>522.603744</ele>
+        <time>2016-10-09T11:58:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139579" lon="11.577478">
+        <ele>522.608228</ele>
+        <time>2016-10-09T11:58:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139593" lon="11.577481">
+        <ele>522.613080</ele>
+        <time>2016-10-09T11:58:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139732" lon="11.577512">
+        <ele>522.661297</ele>
+        <time>2016-10-09T11:58:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139929" lon="11.577501">
+        <ele>522.728935</ele>
+        <time>2016-10-09T11:58:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.139966" lon="11.577498">
+        <ele>522.741648</ele>
+        <time>2016-10-09T11:58:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140054" lon="11.577488">
+        <ele>522.771928</ele>
+        <time>2016-10-09T11:59:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140202" lon="11.577458">
+        <ele>522.823170</ele>
+        <time>2016-10-09T11:59:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140425" lon="11.577414">
+        <ele>522.900342</ele>
+        <time>2016-10-09T11:59:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140490" lon="11.577403">
+        <ele>522.922785</ele>
+        <time>2016-10-09T11:59:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140797" lon="11.577445">
+        <ele>523.028556</ele>
+        <time>2016-10-09T11:59:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.140881" lon="11.577457">
+        <ele>523.057507</ele>
+        <time>2016-10-09T11:59:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141032" lon="11.577497">
+        <ele>523.110118</ele>
+        <time>2016-10-09T11:59:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141129" lon="11.577524">
+        <ele>523.143969</ele>
+        <time>2016-10-09T11:59:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141259" lon="11.577560">
+        <ele>523.189327</ele>
+        <time>2016-10-09T11:59:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141270" lon="11.577563">
+        <ele>523.193163</ele>
+        <time>2016-10-09T11:59:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141278" lon="11.577565">
+        <ele>523.195946</ele>
+        <time>2016-10-09T11:59:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141452" lon="11.577608">
+        <ele>523.032981</ele>
+        <time>2016-10-09T12:00:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141673" lon="11.577657">
+        <ele>522.802584</ele>
+        <time>2016-10-09T12:00:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.141844" lon="11.577692">
+        <ele>522.624596</ele>
+        <time>2016-10-09T12:00:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142355" lon="11.577787">
+        <ele>522.093565</ele>
+        <time>2016-10-09T12:00:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142478" lon="11.577807">
+        <ele>521.965971</ele>
+        <time>2016-10-09T12:00:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142511" lon="11.577824">
+        <ele>521.929984</ele>
+        <time>2016-10-09T12:00:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142531" lon="11.577834">
+        <ele>521.908240</ele>
+        <time>2016-10-09T12:00:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142533" lon="11.577836">
+        <ele>521.905761</ele>
+        <time>2016-10-09T12:00:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142585" lon="11.577886">
+        <ele>521.842044</ele>
+        <time>2016-10-09T12:00:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142703" lon="11.577918">
+        <ele>521.718375</ele>
+        <time>2016-10-09T12:00:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.142783" lon="11.577924">
+        <ele>521.635768</ele>
+        <time>2016-10-09T12:00:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143750" lon="11.578330">
+        <ele>520.137634</ele>
+        <time>2016-10-09T12:01:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.143903" lon="11.578327">
+        <ele>519.881956</ele>
+        <time>2016-10-09T12:01:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144194" lon="11.578469">
+        <ele>519.370582</ele>
+        <time>2016-10-09T12:01:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144248" lon="11.578494">
+        <ele>519.276143</ele>
+        <time>2016-10-09T12:01:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144777" lon="11.578737">
+        <ele>518.351617</ele>
+        <time>2016-10-09T12:02:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144798" lon="11.578790">
+        <ele>518.342852</ele>
+        <time>2016-10-09T12:02:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144931" lon="11.578856">
+        <ele>518.353339</ele>
+        <time>2016-10-09T12:02:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.144984" lon="11.578834">
+        <ele>518.357456</ele>
+        <time>2016-10-09T12:02:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145113" lon="11.578892">
+        <ele>518.367538</ele>
+        <time>2016-10-09T12:02:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145193" lon="11.578936">
+        <ele>518.373917</ele>
+        <time>2016-10-09T12:02:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145244" lon="11.578957">
+        <ele>518.377876</ele>
+        <time>2016-10-09T12:02:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145334" lon="11.578999">
+        <ele>518.384932</ele>
+        <time>2016-10-09T12:02:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145369" lon="11.579014">
+        <ele>518.387657</ele>
+        <time>2016-10-09T12:02:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145444" lon="11.579043">
+        <ele>518.393454</ele>
+        <time>2016-10-09T12:02:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145589" lon="11.579109">
+        <ele>518.404798</ele>
+        <time>2016-10-09T12:02:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145604" lon="11.579117">
+        <ele>518.405990</ele>
+        <time>2016-10-09T12:02:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145750" lon="11.579189">
+        <ele>518.417495</ele>
+        <time>2016-10-09T12:02:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145750" lon="11.579189">
+        <ele>518.417495</ele>
+        <time>2016-10-09T12:02:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145760" lon="11.579194">
+        <ele>518.418284</ele>
+        <time>2016-10-09T12:02:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.145978" lon="11.579304">
+        <ele>518.435503</ele>
+        <time>2016-10-09T12:03:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146015" lon="11.579322">
+        <ele>518.438414</ele>
+        <time>2016-10-09T12:03:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146682" lon="11.579641">
+        <ele>518.565183</ele>
+        <time>2016-10-09T12:03:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146799" lon="11.579695">
+        <ele>518.617192</ele>
+        <time>2016-10-09T12:03:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.146876" lon="11.579732">
+        <ele>518.651544</ele>
+        <time>2016-10-09T12:03:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147352" lon="11.579943">
+        <ele>518.862421</ele>
+        <time>2016-10-09T12:04:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147380" lon="11.580039">
+        <ele>518.892119</ele>
+        <time>2016-10-09T12:04:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147433" lon="11.580063">
+        <ele>518.915640</ele>
+        <time>2016-10-09T12:04:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147518" lon="11.580102">
+        <ele>518.953405</ele>
+        <time>2016-10-09T12:04:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147584" lon="11.580132">
+        <ele>518.982705</ele>
+        <time>2016-10-09T12:04:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147637" lon="11.580155">
+        <ele>519.006146</ele>
+        <time>2016-10-09T12:04:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.147719" lon="11.580106">
+        <ele>519.043648</ele>
+        <time>2016-10-09T12:04:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148253" lon="11.580348">
+        <ele>519.130007</ele>
+        <time>2016-10-09T12:04:50.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148474" lon="11.580449">
+        <ele>518.872859</ele>
+        <time>2016-10-09T12:04:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148867" lon="11.580635">
+        <ele>518.414171</ele>
+        <time>2016-10-09T12:05:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.148955" lon="11.580676">
+        <ele>518.311607</ele>
+        <time>2016-10-09T12:05:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149039" lon="11.580716">
+        <ele>518.213512</ele>
+        <time>2016-10-09T12:05:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149173" lon="11.580783">
+        <ele>518.056294</ele>
+        <time>2016-10-09T12:05:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149306" lon="11.580848">
+        <ele>517.900597</ele>
+        <time>2016-10-09T12:05:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149369" lon="11.580879">
+        <ele>517.826798</ele>
+        <time>2016-10-09T12:05:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149486" lon="11.580936">
+        <ele>517.689874</ele>
+        <time>2016-10-09T12:05:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.149627" lon="11.581005">
+        <ele>517.524792</ele>
+        <time>2016-10-09T12:05:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150097" lon="11.581245">
+        <ele>517.230457</ele>
+        <time>2016-10-09T12:06:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150510" lon="11.581447">
+        <ele>517.218171</ele>
+        <time>2016-10-09T12:06:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.150987" lon="11.581677">
+        <ele>517.203999</ele>
+        <time>2016-10-09T12:06:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151028" lon="11.581711">
+        <ele>517.202674</ele>
+        <time>2016-10-09T12:06:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151151" lon="11.581751">
+        <ele>517.199115</ele>
+        <time>2016-10-09T12:06:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151167" lon="11.581758">
+        <ele>517.198643</ele>
+        <time>2016-10-09T12:06:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151280" lon="11.581794">
+        <ele>517.195376</ele>
+        <time>2016-10-09T12:06:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.151328" lon="11.581956">
+        <ele>517.192032</ele>
+        <time>2016-10-09T12:07:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152018" lon="11.582289">
+        <ele>517.771268</ele>
+        <time>2016-10-09T12:07:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152100" lon="11.582336">
+        <ele>517.869450</ele>
+        <time>2016-10-09T12:07:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152189" lon="11.582387">
+        <ele>517.976009</ele>
+        <time>2016-10-09T12:07:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152240" lon="11.582428">
+        <ele>518.040731</ele>
+        <time>2016-10-09T12:07:46.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152281" lon="11.582457">
+        <ele>518.091433</ele>
+        <time>2016-10-09T12:07:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152751" lon="11.582664">
+        <ele>518.639282</ele>
+        <time>2016-10-09T12:08:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.152881" lon="11.582721">
+        <ele>518.790761</ele>
+        <time>2016-10-09T12:08:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153078" lon="11.582781">
+        <ele>519.015579</ele>
+        <time>2016-10-09T12:08:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153124" lon="11.582763">
+        <ele>519.068748</ele>
+        <time>2016-10-09T12:08:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153160" lon="11.582760">
+        <ele>519.109071</ele>
+        <time>2016-10-09T12:08:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.153552" lon="11.582941">
+        <ele>519.194872</ele>
+        <time>2016-10-09T12:08:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154149" lon="11.583219">
+        <ele>519.189247</ele>
+        <time>2016-10-09T12:09:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.154276" lon="11.583278">
+        <ele>519.188050</ele>
+        <time>2016-10-09T12:09:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155281" lon="11.583757">
+        <ele>518.829029</ele>
+        <time>2016-10-09T12:09:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155379" lon="11.583803">
+        <ele>518.724014</ele>
+        <time>2016-10-09T12:10:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155535" lon="11.583878">
+        <ele>518.556481</ele>
+        <time>2016-10-09T12:10:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.155621" lon="11.583919">
+        <ele>518.464195</ele>
+        <time>2016-10-09T12:10:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156598" lon="11.584366">
+        <ele>517.419597</ele>
+        <time>2016-10-09T12:10:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.156759" lon="11.584439">
+        <ele>517.330094</ele>
+        <time>2016-10-09T12:10:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157030" lon="11.584582">
+        <ele>517.292133</ele>
+        <time>2016-10-09T12:11:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157045" lon="11.584497">
+        <ele>517.284384</ele>
+        <time>2016-10-09T12:11:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157138" lon="11.584536">
+        <ele>517.271624</ele>
+        <time>2016-10-09T12:11:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157142" lon="11.584415">
+        <ele>517.260946</ele>
+        <time>2016-10-09T12:11:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157159" lon="11.584269">
+        <ele>517.247882</ele>
+        <time>2016-10-09T12:11:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157197" lon="11.584267">
+        <ele>517.242858</ele>
+        <time>2016-10-09T12:11:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157269" lon="11.584298">
+        <ele>517.232960</ele>
+        <time>2016-10-09T12:11:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157283" lon="11.584229">
+        <ele>517.226603</ele>
+        <time>2016-10-09T12:11:31.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157344" lon="11.583961">
+        <ele>517.201644</ele>
+        <time>2016-10-09T12:11:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157407" lon="11.583723">
+        <ele>517.179075</ele>
+        <time>2016-10-09T12:11:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157625" lon="11.582742">
+        <ele>517.240570</ele>
+        <time>2016-10-09T12:12:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157632" lon="11.582694">
+        <ele>517.275713</ele>
+        <time>2016-10-09T12:12:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157713" lon="11.582607">
+        <ele>517.382552</ele>
+        <time>2016-10-09T12:12:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157793" lon="11.581552">
+        <ele>518.141993</ele>
+        <time>2016-10-09T12:12:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157877" lon="11.580372">
+        <ele>518.990771</ele>
+        <time>2016-10-09T12:13:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157884" lon="11.580223">
+        <ele>519.003494</ele>
+        <time>2016-10-09T12:13:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157900" lon="11.579904">
+        <ele>518.898056</ele>
+        <time>2016-10-09T12:13:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157911" lon="11.579172">
+        <ele>518.656731</ele>
+        <time>2016-10-09T12:13:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157919" lon="11.578634">
+        <ele>518.479364</ele>
+        <time>2016-10-09T12:14:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157858" lon="11.577568">
+        <ele>518.116981</ele>
+        <time>2016-10-09T12:14:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157839" lon="11.577223">
+        <ele>517.940327</ele>
+        <time>2016-10-09T12:14:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157832" lon="11.577092">
+        <ele>517.873263</ele>
+        <time>2016-10-09T12:14:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157826" lon="11.576989">
+        <ele>517.820502</ele>
+        <time>2016-10-09T12:14:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157757" lon="11.575783">
+        <ele>517.202814</ele>
+        <time>2016-10-09T12:15:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157751" lon="11.575675">
+        <ele>517.147511</ele>
+        <time>2016-10-09T12:15:32.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157742" lon="11.575591">
+        <ele>517.104096</ele>
+        <time>2016-10-09T12:15:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157733" lon="11.575552">
+        <ele>517.083036</ele>
+        <time>2016-10-09T12:15:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157715" lon="11.575089">
+        <ele>516.846364</ele>
+        <time>2016-10-09T12:15:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157712" lon="11.575004">
+        <ele>516.802927</ele>
+        <time>2016-10-09T12:15:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157713" lon="11.574982">
+        <ele>516.791675</ele>
+        <time>2016-10-09T12:15:51.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157714" lon="11.574961">
+        <ele>516.780931</ele>
+        <time>2016-10-09T12:15:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157713" lon="11.574842">
+        <ele>516.805492</ele>
+        <time>2016-10-09T12:15:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157712" lon="11.574575">
+        <ele>516.909524</ele>
+        <time>2016-10-09T12:16:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157754" lon="11.574202">
+        <ele>517.056910</ele>
+        <time>2016-10-09T12:16:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157759" lon="11.574149">
+        <ele>517.077765</ele>
+        <time>2016-10-09T12:16:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157783" lon="11.574018">
+        <ele>517.130696</ele>
+        <time>2016-10-09T12:16:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157911" lon="11.573298">
+        <ele>517.421016</ele>
+        <time>2016-10-09T12:16:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.157954" lon="11.573037">
+        <ele>517.525763</ele>
+        <time>2016-10-09T12:16:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158068" lon="11.572594">
+        <ele>517.710764</ele>
+        <time>2016-10-09T12:17:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158261" lon="11.571886">
+        <ele>518.099684</ele>
+        <time>2016-10-09T12:17:23.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158655" lon="11.570504">
+        <ele>518.965982</ele>
+        <time>2016-10-09T12:18:05.000Z</time>
+      </trkpt>
+      <trkpt lat="48.158987" lon="11.569208">
+        <ele>519.467549</ele>
+        <time>2016-10-09T12:18:44.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159006" lon="11.569076">
+        <ele>519.486223</ele>
+        <time>2016-10-09T12:18:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159029" lon="11.568949">
+        <ele>519.504421</ele>
+        <time>2016-10-09T12:18:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159163" lon="11.568166">
+        <ele>519.616204</ele>
+        <time>2016-10-09T12:19:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159214" lon="11.567869">
+        <ele>519.658613</ele>
+        <time>2016-10-09T12:19:22.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159396" lon="11.566788">
+        <ele>519.597450</ele>
+        <time>2016-10-09T12:19:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159414" lon="11.566676">
+        <ele>519.561899</ele>
+        <time>2016-10-09T12:19:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159428" lon="11.566583">
+        <ele>519.532479</ele>
+        <time>2016-10-09T12:19:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159516" lon="11.566047">
+        <ele>519.362139</ele>
+        <time>2016-10-09T12:20:14.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159605" lon="11.565444">
+        <ele>519.171559</ele>
+        <time>2016-10-09T12:20:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159653" lon="11.565112">
+        <ele>519.066729</ele>
+        <time>2016-10-09T12:20:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159661" lon="11.565052">
+        <ele>519.047848</ele>
+        <time>2016-10-09T12:20:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159671" lon="11.564974">
+        <ele>519.023337</ele>
+        <time>2016-10-09T12:20:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159879" lon="11.563282">
+        <ele>518.771246</ele>
+        <time>2016-10-09T12:21:30.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159890" lon="11.563195">
+        <ele>518.761990</ele>
+        <time>2016-10-09T12:21:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159909" lon="11.563050">
+        <ele>518.746543</ele>
+        <time>2016-10-09T12:21:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.159920" lon="11.562958">
+        <ele>518.736773</ele>
+        <time>2016-10-09T12:21:39.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160006" lon="11.562239">
+        <ele>518.660418</ele>
+        <time>2016-10-09T12:21:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160078" lon="11.561702">
+        <ele>518.628920</ele>
+        <time>2016-10-09T12:22:15.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160084" lon="11.561640">
+        <ele>518.628175</ele>
+        <time>2016-10-09T12:22:16.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160118" lon="11.561547">
+        <ele>518.626915</ele>
+        <time>2016-10-09T12:22:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160166" lon="11.561403">
+        <ele>518.625001</ele>
+        <time>2016-10-09T12:22:24.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160369" lon="11.560801">
+        <ele>518.616983</ele>
+        <time>2016-10-09T12:22:42.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160518" lon="11.560358">
+        <ele>518.611085</ele>
+        <time>2016-10-09T12:22:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160960" lon="11.559036">
+        <ele>518.452170</ele>
+        <time>2016-10-09T12:23:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.160998" lon="11.558921">
+        <ele>518.418296</ele>
+        <time>2016-10-09T12:23:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161135" lon="11.558513">
+        <ele>518.297732</ele>
+        <time>2016-10-09T12:23:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161165" lon="11.558462">
+        <ele>518.279785</ele>
+        <time>2016-10-09T12:23:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161210" lon="11.558462">
+        <ele>518.261978</ele>
+        <time>2016-10-09T12:23:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161287" lon="11.558471">
+        <ele>518.231418</ele>
+        <time>2016-10-09T12:23:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161346" lon="11.558478">
+        <ele>518.207999</ele>
+        <time>2016-10-09T12:24:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161363" lon="11.558480">
+        <ele>518.201251</ele>
+        <time>2016-10-09T12:24:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161378" lon="11.558482">
+        <ele>518.195292</ele>
+        <time>2016-10-09T12:24:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161392" lon="11.558483">
+        <ele>518.189746</ele>
+        <time>2016-10-09T12:24:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161418" lon="11.558486">
+        <ele>518.179428</ele>
+        <time>2016-10-09T12:24:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161457" lon="11.558491">
+        <ele>518.163939</ele>
+        <time>2016-10-09T12:24:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161555" lon="11.558502">
+        <ele>518.125053</ele>
+        <time>2016-10-09T12:24:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161559" lon="11.558422">
+        <ele>518.103878</ele>
+        <time>2016-10-09T12:24:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161568" lon="11.558242">
+        <ele>518.056236</ele>
+        <time>2016-10-09T12:24:17.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161642" lon="11.558146">
+        <ele>518.017513</ele>
+        <time>2016-10-09T12:24:21.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161661" lon="11.557654">
+        <ele>517.887519</ele>
+        <time>2016-10-09T12:24:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161681" lon="11.556970">
+        <ele>517.721199</ele>
+        <time>2016-10-09T12:24:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161683" lon="11.556921">
+        <ele>517.709273</ele>
+        <time>2016-10-09T12:24:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161669" lon="11.554608">
+        <ele>517.112120</ele>
+        <time>2016-10-09T12:25:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161678" lon="11.554515">
+        <ele>517.079941</ele>
+        <time>2016-10-09T12:26:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161680" lon="11.554465">
+        <ele>517.062789</ele>
+        <time>2016-10-09T12:26:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161687" lon="11.553190">
+        <ele>516.626179</ele>
+        <time>2016-10-09T12:26:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161681" lon="11.553160">
+        <ele>516.615455</ele>
+        <time>2016-10-09T12:26:37.000Z</time>
+      </trkpt>
+      <trkpt lat="48.161728" lon="11.553161">
+        <ele>516.591324</ele>
+        <time>2016-10-09T12:26:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162250" lon="11.553170">
+        <ele>516.323333</ele>
+        <time>2016-10-09T12:27:00.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162415" lon="11.553173">
+        <ele>516.297402</ele>
+        <time>2016-10-09T12:27:07.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162496" lon="11.553173">
+        <ele>516.290032</ele>
+        <time>2016-10-09T12:27:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.162965" lon="11.553183">
+        <ele>516.247353</ele>
+        <time>2016-10-09T12:27:29.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163631" lon="11.553197">
+        <ele>516.186747</ele>
+        <time>2016-10-09T12:27:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163757" lon="11.553200">
+        <ele>516.175281</ele>
+        <time>2016-10-09T12:28:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163777" lon="11.553200">
+        <ele>516.173461</ele>
+        <time>2016-10-09T12:28:02.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163911" lon="11.553200">
+        <ele>516.161268</ele>
+        <time>2016-10-09T12:28:08.000Z</time>
+      </trkpt>
+      <trkpt lat="48.163979" lon="11.553205">
+        <ele>516.155073</ele>
+        <time>2016-10-09T12:28:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164923" lon="11.553187">
+        <ele>515.633504</ele>
+        <time>2016-10-09T12:28:49.000Z</time>
+      </trkpt>
+      <trkpt lat="48.164981" lon="11.553187">
+        <ele>515.598457</ele>
+        <time>2016-10-09T12:28:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165058" lon="11.553192">
+        <ele>515.551886</ele>
+        <time>2016-10-09T12:28:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165446" lon="11.553251">
+        <ele>515.316231</ele>
+        <time>2016-10-09T12:29:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.165816" lon="11.553311">
+        <ele>515.091351</ele>
+        <time>2016-10-09T12:29:25.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166179" lon="11.553423">
+        <ele>514.856787</ele>
+        <time>2016-10-09T12:29:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166307" lon="11.553461">
+        <ele>514.773581</ele>
+        <time>2016-10-09T12:29:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.166864" lon="11.553796">
+        <ele>514.390892</ele>
+        <time>2016-10-09T12:30:09.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167237" lon="11.554170">
+        <ele>514.104758</ele>
+        <time>2016-10-09T12:30:27.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167349" lon="11.554283">
+        <ele>514.018676</ele>
+        <time>2016-10-09T12:30:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167444" lon="11.554408">
+        <ele>513.938079</ele>
+        <time>2016-10-09T12:30:38.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167558" lon="11.554556">
+        <ele>514.073695</ele>
+        <time>2016-10-09T12:30:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167609" lon="11.554474">
+        <ele>514.182313</ele>
+        <time>2016-10-09T12:30:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167689" lon="11.554345">
+        <ele>514.352958</ele>
+        <time>2016-10-09T12:30:53.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167763" lon="11.554227">
+        <ele>514.509866</ele>
+        <time>2016-10-09T12:30:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167839" lon="11.554274">
+        <ele>514.629277</ele>
+        <time>2016-10-09T12:31:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.167875" lon="11.554321">
+        <ele>514.698612</ele>
+        <time>2016-10-09T12:31:03.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168129" lon="11.553911">
+        <ele>515.240708</ele>
+        <time>2016-10-09T12:31:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168219" lon="11.553731">
+        <ele>515.458642</ele>
+        <time>2016-10-09T12:31:26.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168344" lon="11.553248">
+        <ele>515.960534</ele>
+        <time>2016-10-09T12:31:41.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168348" lon="11.553182">
+        <ele>516.024734</ele>
+        <time>2016-10-09T12:31:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168375" lon="11.552701">
+        <ele>516.492343</ele>
+        <time>2016-10-09T12:31:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168324" lon="11.552020">
+        <ele>516.834370</ele>
+        <time>2016-10-09T12:32:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168224" lon="11.550677">
+        <ele>517.475831</ele>
+        <time>2016-10-09T12:32:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168244" lon="11.550414">
+        <ele>517.601482</ele>
+        <time>2016-10-09T12:33:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168418" lon="11.549854">
+        <ele>517.652969</ele>
+        <time>2016-10-09T12:33:20.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168669" lon="11.549558">
+        <ele>517.265828</ele>
+        <time>2016-10-09T12:33:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168684" lon="11.549541">
+        <ele>517.243032</ele>
+        <time>2016-10-09T12:33:34.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168933" lon="11.549365">
+        <ele>516.909298</ele>
+        <time>2016-10-09T12:33:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.168990" lon="11.549329">
+        <ele>516.834314</ele>
+        <time>2016-10-09T12:33:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.169198" lon="11.549195">
+        <ele>516.559856</ele>
+        <time>2016-10-09T12:33:56.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170061" lon="11.548648">
+        <ele>515.667974</ele>
+        <time>2016-10-09T12:34:33.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170277" lon="11.548478">
+        <ele>515.731673</ele>
+        <time>2016-10-09T12:34:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170277" lon="11.548478">
+        <ele>515.731673</ele>
+        <time>2016-10-09T12:34:43.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170356" lon="11.548407">
+        <ele>515.755722</ele>
+        <time>2016-10-09T12:34:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170470" lon="11.548302">
+        <ele>515.790657</ele>
+        <time>2016-10-09T12:34:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170504" lon="11.548265">
+        <ele>515.801627</ele>
+        <time>2016-10-09T12:34:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170535" lon="11.548228">
+        <ele>515.811973</ele>
+        <time>2016-10-09T12:34:55.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170571" lon="11.548187">
+        <ele>515.823777</ele>
+        <time>2016-10-09T12:34:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170602" lon="11.548148">
+        <ele>515.834343</ele>
+        <time>2016-10-09T12:34:59.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170719" lon="11.547989">
+        <ele>515.875574</ele>
+        <time>2016-10-09T12:35:06.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170817" lon="11.547846">
+        <ele>515.911280</ele>
+        <time>2016-10-09T12:35:11.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170849" lon="11.547794">
+        <ele>515.923602</ele>
+        <time>2016-10-09T12:35:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.170921" lon="11.547673">
+        <ele>515.951840</ele>
+        <time>2016-10-09T12:35:18.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171140" lon="11.547151">
+        <ele>516.059233</ele>
+        <time>2016-10-09T12:35:36.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171186" lon="11.547040">
+        <ele>516.081990</ele>
+        <time>2016-10-09T12:35:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171243" lon="11.546860">
+        <ele>516.292288</ele>
+        <time>2016-10-09T12:35:45.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171270" lon="11.546764">
+        <ele>516.453277</ele>
+        <time>2016-10-09T12:35:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171332" lon="11.546455">
+        <ele>516.951879</ele>
+        <time>2016-10-09T12:35:58.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171377" lon="11.546261">
+        <ele>517.269258</ele>
+        <time>2016-10-09T12:36:04.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171436" lon="11.545987">
+        <ele>517.714157</ele>
+        <time>2016-10-09T12:36:13.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171728" lon="11.545244">
+        <ele>519.046734</ele>
+        <time>2016-10-09T12:36:40.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171838" lon="11.545071">
+        <ele>519.416074</ele>
+        <time>2016-10-09T12:36:48.000Z</time>
+      </trkpt>
+      <trkpt lat="48.171952" lon="11.544921">
+        <ele>519.767477</ele>
+        <time>2016-10-09T12:36:54.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172077" lon="11.544781">
+        <ele>520.128965</ele>
+        <time>2016-10-09T12:37:01.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172298" lon="11.544569">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:12.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172639" lon="11.544352">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:28.000Z</time>
+      </trkpt>
+      <trkpt lat="48.172786" lon="11.544295">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:35.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173096" lon="11.544214">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:47.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173205" lon="11.544205">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:52.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173327" lon="11.544210">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:37:57.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173651" lon="11.544275">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:38:10.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173870" lon="11.544361">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:38:19.000Z</time>
+      </trkpt>
+      <trkpt lat="48.173870" lon="11.544361">
+        <ele>520.261730</ele>
+        <time>2016-10-09T12:38:19.000Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/tests/test_osm_pipeline.py
+++ b/tests/test_osm_pipeline.py
@@ -1,17 +1,20 @@
-"""Tests for PR: osm-threading-pr
+"""Unit and integration tests for the TrailPrint3D OSM data pipeline.
 
-Validates:
-  A3 — _overpass_request centralised retry logic (osm.py)
-  A1 — bmesh flood-fill loose-part splitting (terrain.py)
-  A2 — bmesh ribbon merge (terrain.py)
-  B1 — coloring_main prefetched_tiles parameter (terrain.py)
-  B2 — _fetch_tiles_parallel concurrent fetcher (terrain.py)
+Covers:
+  - Overpass HTTP request logic (retry, error handling, GET vs POST)
+  - Per-tile parallel fetcher (_fetch_tiles_parallel)
+  - Multi-kind parallel fetcher (_fetch_all_kinds_parallel)
+  - Union query and element classifier (fetch_osm_combined)
+  - coloring_main API surface
+  - bmesh flood-fill loose-part splitting
+  - bmesh ribbon merge
+  - Live Overpass API integration (requires network, ~5-20 s each)
 
 Run with:
-  blender --background --factory-startup --python-exit-code 1 -P tests/test_pr_osm_threading.py
+  blender --background --factory-startup --python-exit-code 1 -P tests/test_osm_pipeline.py
 
---python-exit-code 1 means any unhandled exception (including AssertionError)
-causes Blender to exit with code 1, making failures visible to CI / PowerShell.
+--python-exit-code 1 exits Blender with code 1 on any unhandled exception
+(including AssertionError), making failures visible to CI.
 """
 
 import sys
@@ -69,7 +72,7 @@ def _make_response(status_code, body=None):
 
 
 # ---------------------------------------------------------------------------
-# A3 — _overpass_request
+# Overpass HTTP request — retry and error handling
 # ---------------------------------------------------------------------------
 
 def test_overpass_request_success_first_try():
@@ -160,7 +163,7 @@ def test_overpass_request_get_method():
 
 
 # ---------------------------------------------------------------------------
-# B2 — _fetch_tiles_parallel
+# Per-tile parallel fetcher — _fetch_tiles_parallel
 # ---------------------------------------------------------------------------
 
 def test_fetch_tiles_parallel_all_tiles_fetched():
@@ -310,7 +313,7 @@ def test_fetch_tiles_parallel_semaphore_caps_concurrency():
 
 
 # ---------------------------------------------------------------------------
-# B1 — coloring_main signature
+# coloring_main API surface
 # ---------------------------------------------------------------------------
 
 def test_coloring_main_has_prefetched_tiles_param():
@@ -325,8 +328,8 @@ def test_coloring_main_has_prefetched_tiles_param():
 
 
 # ---------------------------------------------------------------------------
-# A1 — bmesh flood-fill loose-part splitting algorithm
-# (The same algorithm used in _split_loose inside _process_coloring_object)
+# bmesh flood-fill — loose-part splitting
+# (mirrors the _split_loose algorithm used in _process_coloring_object)
 # ---------------------------------------------------------------------------
 
 def _flood_fill_components(bm_src):
@@ -461,7 +464,7 @@ def test_split_loose_produces_correct_objects_in_scene():
 
 
 # ---------------------------------------------------------------------------
-# A2 — bmesh ribbon merge
+# bmesh ribbon merge
 # ---------------------------------------------------------------------------
 
 def _make_quad_object(name, x_offset):
@@ -531,9 +534,103 @@ def test_ribbon_merge_single_ribbon_is_unchanged():
 
 
 # ---------------------------------------------------------------------------
-# Entry point
+# Live Overpass API integration — real network, no mocks
 # ---------------------------------------------------------------------------
-# B3 — _fetch_all_kinds_parallel  (cross-kind parallel fetch)
+# Hits overpass-api.de directly using a small bbox from the München Marathon
+# GPX route (English Garden area, ~2×2 km).  Requires internet access.
+# Expected duration: 5–20 s each.
+#
+# Bbox: 48.140–48.160 N, 11.550–11.580 E
+# ---------------------------------------------------------------------------
+
+_MUNICH_BBOX = (48.140, 11.550, 48.160, 11.580)  # (south, west, north, east)
+
+
+def _munich_settings(**overrides):
+    """Return an OsmFetchSettings for the Munich integration bbox."""
+    from TrailPrint3D.utils.osm import OsmFetchSettings
+    defaults = dict(
+        disable_cache=True,  # always go to the network; no stale results
+        api_retries=2,
+        mapsize=5.0,
+        road_big=True,
+        road_med=True,
+        road_small=False,
+        water_ponds=True,
+        water_small_rivers=True,
+        water_big_rivers=True,
+    )
+    defaults.update(overrides)
+    return OsmFetchSettings(**defaults)
+
+
+def test_real_overpass_union_query():
+    """The union QL query must be accepted by the Overpass server and return
+    a non-empty elements list for a well-populated urban area (Munich)."""
+    import threading
+    from TrailPrint3D.utils.osm import fetch_osm_combined
+
+    result = fetch_osm_combined(
+        _MUNICH_BBOX,
+        ["STREETS", "WATER", "FOREST"],
+        settings=_munich_settings(),
+        semaphore=threading.Semaphore(1),
+    )
+
+    assert result, "Overpass returned no data at all — check network/query syntax"
+    print()
+    total_elements = 0
+    for kind, (data, from_cache) in result.items():
+        elems = data.get("elements", [])
+        ways = [e for e in elems if e.get("type") != "node"]
+        print(f"    {kind:12s}: {len(elems):4d} elements  ({len(ways)} ways/relations)")
+        total_elements += len(elems)
+    assert total_elements > 0, "All kinds returned empty element lists"
+
+
+def test_real_overpass_classifier():
+    """Every returned way/relation must be binned into the correct kind.
+    Central Munich must yield at least one element in each of the three
+    requested kinds — STREETS, WATER, and FOREST."""
+    import threading
+    from TrailPrint3D.utils.osm import fetch_osm_combined, _classify_element
+
+    settings = _munich_settings()
+    result = fetch_osm_combined(
+        _MUNICH_BBOX,
+        ["STREETS", "WATER", "FOREST"],
+        settings=settings,
+        semaphore=threading.Semaphore(1),
+    )
+
+    print()
+    for kind in ["STREETS", "WATER", "FOREST"]:
+        assert kind in result, (
+            f"Kind {kind!r} missing from result — "
+            f"got: {list(result.keys())}"
+        )
+        data, _ = result[kind]
+        ways = [e for e in data.get("elements", []) if e.get("type") != "node"]
+        assert ways, (
+            f"Kind {kind!r} has no ways or relations — classifier may have "
+            f"dropped everything.  Check tag filters in _classify_element."
+        )
+        # Spot-check: every classified way should round-trip through the
+        # classifier back to the same kind (no misclassification)
+        wrong = [
+            e for e in ways
+            if _classify_element(e, [kind], settings) != kind
+        ]
+        assert not wrong, (
+            f"{len(wrong)} element(s) in the {kind!r} bucket failed "
+            f"round-trip classification.  First offender tags: "
+            f"{wrong[0].get('tags', {})}"
+        )
+        print(f"    {kind:12s}: {len(ways)} ways/relations — all correctly classified")
+
+
+# ---------------------------------------------------------------------------
+# Multi-kind parallel fetcher — _fetch_all_kinds_parallel
 # ---------------------------------------------------------------------------
 
 def test_fetch_all_kinds_fetches_every_kind():
@@ -542,71 +639,72 @@ def test_fetch_all_kinds_fetches_every_kind():
     from unittest.mock import patch
     from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
 
-    tasks = [(0.0, 0.0, 2.0, 2.0)]
+    bbox = (0.0, 0.0, 2.0, 2.0)
     kinds = ["WATER", "FOREST", "SCREE"]
-    kind_task_pairs = [(k, tasks) for k in kinds]
+    kind_task_pairs = [(k, [bbox]) for k in kinds]
 
-    def _mock(bbox, kind, return_cache_status=False, settings=None):
-        return ({"elements": []}, True)
+    def _mock(b, ks, settings=None, semaphore=None):
+        return {k: ({"elements": []}, True) for k in ks}
 
-    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+    with patch("TrailPrint3D.utils.osm.fetch_osm_combined", _mock):
         result = _fetch_all_kinds_parallel(kind_task_pairs, threading.Semaphore(4))
 
     for k in kinds:
         assert k in result, f"Kind {k} missing from result"
-        assert tasks[0] in result[k], f"Tile missing for kind {k}"
+        assert bbox in result[k], f"Tile missing for kind {k}"
 
 
 def test_fetch_all_kinds_failed_kind_excluded():
-    """A kind whose fetch returns None must have an empty dict in the result."""
+    """A kind whose fetch returns nothing must have an empty dict in the result."""
     import threading
     from unittest.mock import patch
     from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
 
-    tasks = [(0.0, 0.0, 2.0, 2.0)]
+    bbox = (0.0, 0.0, 2.0, 2.0)
 
-    def _mock(bbox, kind, return_cache_status=False, settings=None):
-        if kind == "WATER":
-            return ({"elements": []}, False)
-        return None  # FOREST fails
+    def _mock(b, ks, settings=None, semaphore=None):
+        # Return WATER but silently drop FOREST (simulate no matching elements)
+        return {k: ({"elements": []}, False) for k in ks if k == "WATER"}
 
-    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+    with patch("TrailPrint3D.utils.osm.fetch_osm_combined", _mock):
         result = _fetch_all_kinds_parallel(
-            [("WATER", tasks), ("FOREST", tasks)],
+            [("WATER", [bbox]), ("FOREST", [bbox])],
             threading.Semaphore(4),
         )
 
-    assert tasks[0] in result["WATER"], "Successful kind should have its tile"
+    assert bbox in result["WATER"], "Successful kind should have its tile"
     assert result["FOREST"] == {}, "Failed kind should be an empty dict"
 
 
 def test_fetch_all_kinds_actually_concurrent():
-    """All kinds must be in-flight simultaneously (barrier proof)."""
+    """All tile tasks must be in-flight simultaneously (barrier proof)."""
     import threading
     from unittest.mock import patch
     from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
 
-    N_KINDS = 4
-    barrier = threading.Barrier(N_KINDS, timeout=5)
-    tasks   = [(0.0, 0.0, 2.0, 2.0)]
-    kind_task_pairs = [(f"KIND{i}", tasks) for i in range(N_KINDS)]
+    N_TILES = 4
+    barrier = threading.Barrier(N_TILES, timeout=5)
+    # Use distinct bboxes so each becomes a separate worker task
+    tiles = [(float(i), float(i), float(i) + 1.0, float(i) + 1.0) for i in range(N_TILES)]
+    kind_task_pairs = [("FOREST", tiles)]
 
-    def _mock(bbox, kind, return_cache_status=False, settings=None):
-        barrier.wait()   # all N_KINDS threads must be here simultaneously
-        return ({"elements": []}, False)
+    def _mock(bbox, kinds, settings=None, semaphore=None):
+        barrier.wait()   # all N_TILES threads must arrive here simultaneously
+        return {k: ({"elements": []}, False) for k in kinds}
 
-    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+    with patch("TrailPrint3D.utils.osm.fetch_osm_combined", _mock):
         result = _fetch_all_kinds_parallel(
             kind_task_pairs,
-            threading.Semaphore(N_KINDS),   # semaphore not the bottleneck
-            max_workers=N_KINDS,
+            threading.Semaphore(N_TILES),   # semaphore not the bottleneck
+            max_workers=N_TILES,
         )
 
-    assert len(result) == N_KINDS
+    assert "FOREST" in result
+    assert len(result["FOREST"]) == N_TILES
 
 
 def test_fetch_all_kinds_semaphore_caps_concurrency():
-    """Shared semaphore must limit peak across ALL kinds combined."""
+    """Shared semaphore must limit peak concurrent Overpass requests."""
     import threading
     from unittest.mock import patch
     from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
@@ -617,20 +715,22 @@ def test_fetch_all_kinds_semaphore_caps_concurrency():
     lock   = threading.Lock()
     gate   = threading.Barrier(SEM_LIMIT, timeout=5)
 
-    tasks = [(0.0, 0.0, 2.0, 2.0)]
-    # 6 kinds × 1 tile = 6 total tasks, semaphore(2) should cap to ≤ 2
-    kind_task_pairs = [(f"KIND{i}", tasks) for i in range(6)]
+    # 6 distinct tiles × 1 kind = 6 tile tasks; semaphore(2) caps to ≤ 2 concurrent
+    tiles = [(float(i), float(i), float(i) + 1.0, float(i) + 1.0) for i in range(6)]
+    kind_task_pairs = [("FOREST", tiles)]
 
-    def _mock(bbox, kind, return_cache_status=False, settings=None):
+    def _mock(bbox, kinds, settings=None, semaphore=None):
+        # _fetch_tile holds the semaphore while calling us, so active count
+        # directly reflects semaphore occupancy.
         with lock:
             active[0] += 1
             peak[0] = max(peak[0], active[0])
         gate.wait()
         with lock:
             active[0] -= 1
-        return ({"elements": []}, False)
+        return {k: ({"elements": []}, False) for k in kinds}
 
-    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+    with patch("TrailPrint3D.utils.osm.fetch_osm_combined", _mock):
         result = _fetch_all_kinds_parallel(
             kind_task_pairs,
             threading.Semaphore(SEM_LIMIT),
@@ -639,48 +739,52 @@ def test_fetch_all_kinds_semaphore_caps_concurrency():
 
     assert peak[0] <= SEM_LIMIT, \
         f"Semaphore({SEM_LIMIT}) exceeded: peak was {peak[0]}"
-    assert len(result) == 6
+    assert len(result["FOREST"]) == 6
 
 
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     print("\n" + "=" * 60)
-    print("  TrailPrint3D — osm-threading-pr test suite")
+    print("  TrailPrint3D OSM pipeline tests")
     print("=" * 60 + "\n")
 
-    # A3 — _overpass_request
-    _run("A3  success on first try",            test_overpass_request_success_first_try)
-    _run("A3  retry on 4xx then succeed",        test_overpass_request_retries_then_succeeds)
-    _run("A3  exhausted retries → None",         test_overpass_request_exhausted_returns_none)
-    _run("A3  Timeout triggers retry",           test_overpass_request_timeout_triggers_retry)
-    _run("A3  log_callback fired on error",      test_overpass_request_log_callback_called_on_error)
-    _run("A3  GET method uses requests.get",     test_overpass_request_get_method)
+    # Overpass HTTP request
+    _run("overpass request: success on first try",        test_overpass_request_success_first_try)
+    _run("overpass request: retry on 4xx then succeed",   test_overpass_request_retries_then_succeeds)
+    _run("overpass request: exhausted retries → None",    test_overpass_request_exhausted_returns_none)
+    _run("overpass request: Timeout triggers retry",      test_overpass_request_timeout_triggers_retry)
+    _run("overpass request: log_callback fired on error", test_overpass_request_log_callback_called_on_error)
+    _run("overpass request: GET method uses requests.get",test_overpass_request_get_method)
 
-    # B2 — _fetch_tiles_parallel
-    _run("B2  all tiles fetched",                test_fetch_tiles_parallel_all_tiles_fetched)
-    _run("B2  failed tile excluded from result", test_fetch_tiles_parallel_failed_tile_excluded)
-    _run("B2  result carries from_cache flag",   test_fetch_tiles_parallel_result_carries_cache_flag)
-    _run("B2  Semaphore(1) no deadlock",         test_fetch_tiles_parallel_respects_semaphore)
-    _run("B2  threads genuinely concurrent",     test_fetch_tiles_parallel_actually_concurrent)
-    _run("B2  semaphore caps peak concurrency",  test_fetch_tiles_parallel_semaphore_caps_concurrency)
+    # Per-tile parallel fetcher
+    _run("tile fetcher: all tiles fetched",               test_fetch_tiles_parallel_all_tiles_fetched)
+    _run("tile fetcher: failed tile excluded from result",test_fetch_tiles_parallel_failed_tile_excluded)
+    _run("tile fetcher: result carries from_cache flag",  test_fetch_tiles_parallel_result_carries_cache_flag)
+    _run("tile fetcher: Semaphore(1) no deadlock",        test_fetch_tiles_parallel_respects_semaphore)
+    _run("tile fetcher: threads genuinely concurrent",    test_fetch_tiles_parallel_actually_concurrent)
+    _run("tile fetcher: semaphore caps peak concurrency", test_fetch_tiles_parallel_semaphore_caps_concurrency)
 
-    # B3 — _fetch_all_kinds_parallel
-    _run("B3  all kinds fetched",                test_fetch_all_kinds_fetches_every_kind)
-    _run("B3  failed kind → empty dict",         test_fetch_all_kinds_failed_kind_excluded)
-    _run("B3  kinds genuinely concurrent",       test_fetch_all_kinds_actually_concurrent)
-    _run("B3  semaphore caps cross-kind concurrency", test_fetch_all_kinds_semaphore_caps_concurrency)
+    # Multi-kind parallel fetcher
+    _run("kind fetcher: all kinds fetched",               test_fetch_all_kinds_fetches_every_kind)
+    _run("kind fetcher: failed kind → empty dict",        test_fetch_all_kinds_failed_kind_excluded)
+    _run("kind fetcher: kinds genuinely concurrent",      test_fetch_all_kinds_actually_concurrent)
+    _run("kind fetcher: semaphore caps concurrency",      test_fetch_all_kinds_semaphore_caps_concurrency)
 
-    # B1 — coloring_main signature
-    _run("B1  prefetched_tiles param exists",    test_coloring_main_has_prefetched_tiles_param)
+    # coloring_main API
+    _run("coloring_main: prefetched_tiles param exists",  test_coloring_main_has_prefetched_tiles_param)
 
-    # A1 — bmesh split_loose algorithm
-    _run("A1  two disconnected triangles → 2",   test_split_loose_two_disconnected_triangles)
-    _run("A1  single connected mesh → 1",        test_split_loose_single_connected_mesh)
-    _run("A1  three islands → 3",                test_split_loose_three_islands)
-    _run("A1  end-to-end object creation",       test_split_loose_produces_correct_objects_in_scene)
+    # bmesh flood-fill
+    _run("split loose: two disconnected triangles → 2",   test_split_loose_two_disconnected_triangles)
+    _run("split loose: single connected mesh → 1",        test_split_loose_single_connected_mesh)
+    _run("split loose: three islands → 3",                test_split_loose_three_islands)
+    _run("split loose: end-to-end object creation",       test_split_loose_produces_correct_objects_in_scene)
 
-    # A2 — bmesh ribbon merge
-    _run("A2  two ribbons merged → 8 verts",     test_ribbon_merge_vertex_count)
-    _run("A2  single ribbon fast path",          test_ribbon_merge_single_ribbon_is_unchanged)
+    # bmesh ribbon merge
+    _run("ribbon merge: two ribbons merged → 8 verts",    test_ribbon_merge_vertex_count)
+    _run("ribbon merge: single ribbon fast path",         test_ribbon_merge_single_ribbon_is_unchanged)
+
+    # Live Overpass integration (network required)
+    _run("live overpass: union query accepted by server", test_real_overpass_union_query)
+    _run("live overpass: classifier bins Munich elements",test_real_overpass_classifier)
 
     _assert_all_passed()

--- a/tests/test_pr_osm_threading.py
+++ b/tests/test_pr_osm_threading.py
@@ -171,7 +171,7 @@ def test_fetch_tiles_parallel_all_tiles_fetched():
     tasks = [(0.0, 0.0, 2.0, 2.0), (2.0, 0.0, 4.0, 2.0), (4.0, 0.0, 6.0, 2.0)]
     captured = []
 
-    def _mock_fetch(bbox, kind, return_cache_status=False):
+    def _mock_fetch(bbox, kind, return_cache_status=False, settings=None):
         captured.append(bbox)
         return ({"elements": []}, True)
 
@@ -192,7 +192,7 @@ def test_fetch_tiles_parallel_failed_tile_excluded():
     good = (0.0, 0.0, 2.0, 2.0)
     bad  = (2.0, 0.0, 4.0, 2.0)
 
-    def _mock_fetch(bbox, kind, return_cache_status=False):
+    def _mock_fetch(bbox, kind, return_cache_status=False, settings=None):
         if bbox == good:
             return ({"elements": []}, False)
         return None  # simulate failure
@@ -212,7 +212,7 @@ def test_fetch_tiles_parallel_result_carries_cache_flag():
 
     bbox = (0.0, 0.0, 2.0, 2.0)
 
-    def _mock_fetch(b, kind, return_cache_status=False):
+    def _mock_fetch(b, kind, return_cache_status=False, settings=None):
         return ({"elements": []}, True)   # from_cache = True
 
     with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
@@ -230,7 +230,7 @@ def test_fetch_tiles_parallel_respects_semaphore():
 
     tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
 
-    def _mock_fetch(bbox, kind, return_cache_status=False):
+    def _mock_fetch(bbox, kind, return_cache_status=False, settings=None):
         return ({"elements": []}, False)
 
     with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
@@ -259,7 +259,7 @@ def test_fetch_tiles_parallel_actually_concurrent():
     barrier = threading.Barrier(CONCURRENCY_TARGET, timeout=5)
     tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
 
-    def _mock_fetch(bbox, kind, return_cache_status=False):
+    def _mock_fetch(bbox, kind, return_cache_status=False, settings=None):
         barrier.wait()   # blocks until CONCURRENCY_TARGET threads are all here
         return ({"elements": []}, False)
 
@@ -291,7 +291,7 @@ def test_fetch_tiles_parallel_semaphore_caps_concurrency():
 
     tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
 
-    def _mock_fetch(bbox, kind, return_cache_status=False):
+    def _mock_fetch(bbox, kind, return_cache_status=False, settings=None):
         with lock:
             active[0] += 1
             peak[0] = max(peak[0], active[0])
@@ -546,7 +546,7 @@ def test_fetch_all_kinds_fetches_every_kind():
     kinds = ["WATER", "FOREST", "SCREE"]
     kind_task_pairs = [(k, tasks) for k in kinds]
 
-    def _mock(bbox, kind, return_cache_status=False):
+    def _mock(bbox, kind, return_cache_status=False, settings=None):
         return ({"elements": []}, True)
 
     with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
@@ -565,7 +565,7 @@ def test_fetch_all_kinds_failed_kind_excluded():
 
     tasks = [(0.0, 0.0, 2.0, 2.0)]
 
-    def _mock(bbox, kind, return_cache_status=False):
+    def _mock(bbox, kind, return_cache_status=False, settings=None):
         if kind == "WATER":
             return ({"elements": []}, False)
         return None  # FOREST fails
@@ -591,7 +591,7 @@ def test_fetch_all_kinds_actually_concurrent():
     tasks   = [(0.0, 0.0, 2.0, 2.0)]
     kind_task_pairs = [(f"KIND{i}", tasks) for i in range(N_KINDS)]
 
-    def _mock(bbox, kind, return_cache_status=False):
+    def _mock(bbox, kind, return_cache_status=False, settings=None):
         barrier.wait()   # all N_KINDS threads must be here simultaneously
         return ({"elements": []}, False)
 
@@ -621,7 +621,7 @@ def test_fetch_all_kinds_semaphore_caps_concurrency():
     # 6 kinds × 1 tile = 6 total tasks, semaphore(2) should cap to ≤ 2
     kind_task_pairs = [(f"KIND{i}", tasks) for i in range(6)]
 
-    def _mock(bbox, kind, return_cache_status=False):
+    def _mock(bbox, kind, return_cache_status=False, settings=None):
         with lock:
             active[0] += 1
             peak[0] = max(peak[0], active[0])

--- a/tests/test_pr_osm_threading.py
+++ b/tests/test_pr_osm_threading.py
@@ -1,0 +1,686 @@
+"""Tests for PR: osm-threading-pr
+
+Validates:
+  A3 — _overpass_request centralised retry logic (osm.py)
+  A1 — bmesh flood-fill loose-part splitting (terrain.py)
+  A2 — bmesh ribbon merge (terrain.py)
+  B1 — coloring_main prefetched_tiles parameter (terrain.py)
+  B2 — _fetch_tiles_parallel concurrent fetcher (terrain.py)
+
+Run with:
+  blender --background --factory-startup --python-exit-code 1 -P tests/test_pr_osm_threading.py
+
+--python-exit-code 1 means any unhandled exception (including AssertionError)
+causes Blender to exit with code 1, making failures visible to CI / PowerShell.
+"""
+
+import sys
+import os
+import traceback
+
+import bpy         # type: ignore  — provided by Blender's Python
+import bmesh       # type: ignore
+from mathutils import Vector  # type: ignore
+
+# ---------------------------------------------------------------------------
+# Path setup — makes TrailPrint3D importable as a package from source
+# ---------------------------------------------------------------------------
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# ---------------------------------------------------------------------------
+# Minimal test runner
+# ---------------------------------------------------------------------------
+_passed = 0
+_failed = 0
+
+def _run(name, fn):
+    global _passed, _failed
+    try:
+        fn()
+        print(f"  PASS  {name}")
+        _passed += 1
+    except Exception:
+        print(f"  FAIL  {name}")
+        traceback.print_exc()
+        _failed += 1
+
+
+def _assert_all_passed():
+    print(f"\n{'='*60}")
+    print(f"  {_passed} passed, {_failed} failed")
+    print(f"{'='*60}\n")
+    if _failed:
+        raise SystemExit(1)   # non-zero → Blender exits with code 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code, body=None):
+    """Return a mock requests.Response with the given status and JSON body."""
+    from unittest.mock import MagicMock
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = body if body is not None else {"elements": []}
+    return r
+
+
+# ---------------------------------------------------------------------------
+# A3 — _overpass_request
+# ---------------------------------------------------------------------------
+
+def test_overpass_request_success_first_try():
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    data = {"elements": [{"type": "node", "id": 1}]}
+    resp = _make_response(200, data)
+    with patch("TrailPrint3D.utils.osm.requests.post", return_value=resp) as mp, \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        result = _overpass_request("query", "https://example.com", max_retries=3)
+
+    assert result == data, f"Expected data dict, got {result!r}"
+    assert mp.call_count == 1, f"Expected 1 POST, got {mp.call_count}"
+
+
+def test_overpass_request_retries_then_succeeds():
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    data = {"elements": []}
+    fail = _make_response(429)
+    ok   = _make_response(200, data)
+    with patch("TrailPrint3D.utils.osm.requests.post", side_effect=[fail, fail, ok]), \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        result = _overpass_request("query", "https://example.com", max_retries=5)
+
+    assert result == data, f"Expected data after retry, got {result!r}"
+
+
+def test_overpass_request_exhausted_returns_none():
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    fail = _make_response(500)
+    with patch("TrailPrint3D.utils.osm.requests.post", return_value=fail), \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        result = _overpass_request("query", "https://example.com", max_retries=3)
+
+    assert result is None, f"Expected None after exhausted retries, got {result!r}"
+
+
+def test_overpass_request_timeout_triggers_retry():
+    import requests as _requests
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    ok = _make_response(200, {"elements": []})
+    with patch("TrailPrint3D.utils.osm.requests.post",
+               side_effect=[_requests.exceptions.Timeout, ok]), \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        result = _overpass_request("query", "https://example.com", max_retries=3)
+
+    assert result is not None, "Expected success after one Timeout, got None"
+
+
+def test_overpass_request_log_callback_called_on_error():
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    messages = []
+    fail = _make_response(503)
+    ok   = _make_response(200, {"elements": []})
+    with patch("TrailPrint3D.utils.osm.requests.post", side_effect=[fail, ok]), \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        _overpass_request("query", "https://example.com",
+                          max_retries=3, log_callback=messages.append)
+
+    assert messages, "log_callback should have been called on HTTP error"
+
+
+def test_overpass_request_get_method():
+    """method='GET' uses requests.get, not requests.post."""
+    from unittest.mock import patch
+    from TrailPrint3D.utils.osm import _overpass_request
+
+    data = {"elements": []}
+    resp = _make_response(200, data)
+    with patch("TrailPrint3D.utils.osm.requests.get", return_value=resp) as mg, \
+         patch("TrailPrint3D.utils.osm.requests.post") as mp, \
+         patch("TrailPrint3D.utils.osm.time.sleep"):
+        result = _overpass_request("query", "https://example.com",
+                                   method="GET", max_retries=1)
+
+    assert result == data
+    assert mg.call_count == 1, "GET method should use requests.get"
+    assert mp.call_count == 0, "GET method should not use requests.post"
+
+
+# ---------------------------------------------------------------------------
+# B2 — _fetch_tiles_parallel
+# ---------------------------------------------------------------------------
+
+def test_fetch_tiles_parallel_all_tiles_fetched():
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    tasks = [(0.0, 0.0, 2.0, 2.0), (2.0, 0.0, 4.0, 2.0), (4.0, 0.0, 6.0, 2.0)]
+    captured = []
+
+    def _mock_fetch(bbox, kind, return_cache_status=False):
+        captured.append(bbox)
+        return ({"elements": []}, True)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        sem = threading.Semaphore(2)
+        result = _fetch_tiles_parallel(tasks, "WATER", sem)
+
+    assert set(captured) == set(tasks), \
+        f"Expected {set(tasks)}, got {set(captured)}"
+    assert len(result) == 3, f"Expected 3 results, got {len(result)}"
+
+
+def test_fetch_tiles_parallel_failed_tile_excluded():
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    good = (0.0, 0.0, 2.0, 2.0)
+    bad  = (2.0, 0.0, 4.0, 2.0)
+
+    def _mock_fetch(bbox, kind, return_cache_status=False):
+        if bbox == good:
+            return ({"elements": []}, False)
+        return None  # simulate failure
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        sem = threading.Semaphore(2)
+        result = _fetch_tiles_parallel([good, bad], "WATER", sem)
+
+    assert good in result, "Successful tile should be in result"
+    assert bad not in result, "Failed tile should not be in result"
+
+
+def test_fetch_tiles_parallel_result_carries_cache_flag():
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    bbox = (0.0, 0.0, 2.0, 2.0)
+
+    def _mock_fetch(b, kind, return_cache_status=False):
+        return ({"elements": []}, True)   # from_cache = True
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        result = _fetch_tiles_parallel([bbox], "WATER", __import__("threading").Semaphore(1))
+
+    data, from_cache = result[bbox]
+    assert from_cache is True
+
+
+def test_fetch_tiles_parallel_respects_semaphore():
+    """Semaphore(1) must limit concurrency — verify no deadlock and correct output."""
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
+
+    def _mock_fetch(bbox, kind, return_cache_status=False):
+        return ({"elements": []}, False)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        sem = threading.Semaphore(1)   # strictest rate limit
+        result = _fetch_tiles_parallel(tasks, "FOREST", sem)
+
+    assert len(result) == len(tasks), \
+        f"Expected {len(tasks)} results with Semaphore(1), got {len(result)}"
+
+
+def test_fetch_tiles_parallel_actually_concurrent():
+    """Prove that multiple fetches genuinely run at the same time.
+
+    Strategy: use a threading.Barrier(3) inside the mock fetch.  The barrier
+    only releases when exactly 3 threads call barrier.wait() simultaneously.
+    If the pool runs fetches one-at-a-time (sequential), the third thread never
+    arrives and barrier.wait() raises BrokenBarrierError — test fails.
+    If the pool truly runs at least 3 threads concurrently, all three reach the
+    barrier and it releases cleanly — test passes.
+    """
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    CONCURRENCY_TARGET = 3
+    barrier = threading.Barrier(CONCURRENCY_TARGET, timeout=5)
+    tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
+
+    def _mock_fetch(bbox, kind, return_cache_status=False):
+        barrier.wait()   # blocks until CONCURRENCY_TARGET threads are all here
+        return ({"elements": []}, False)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        sem = threading.Semaphore(CONCURRENCY_TARGET + 1)  # not the bottleneck
+        result = _fetch_tiles_parallel(tasks, "WATER", sem, max_workers=CONCURRENCY_TARGET + 1)
+
+    assert len(result) == len(tasks)
+
+
+def test_fetch_tiles_parallel_semaphore_caps_concurrency():
+    """Prove that the semaphore actually limits how many fetches run at once.
+
+    Strategy: track peak in-flight count with an atomic counter.  Each mock
+    fetch increments on entry, records the peak, then decrements on exit.
+    The semaphore is set to 2, so peak must never exceed 2.
+    """
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_tiles_parallel
+
+    SEM_LIMIT = 2
+    active = [0]          # mutable int (list to allow nonlocal-style mutation)
+    peak   = [0]
+    lock   = threading.Lock()
+    # Barrier forces all threads that get through the semaphore to overlap,
+    # so we get a reliable peak reading rather than a lucky sequential one.
+    gate   = threading.Barrier(SEM_LIMIT, timeout=5)
+
+    tasks = [(float(i), 0.0, float(i + 2), 2.0) for i in range(6)]
+
+    def _mock_fetch(bbox, kind, return_cache_status=False):
+        with lock:
+            active[0] += 1
+            peak[0] = max(peak[0], active[0])
+        gate.wait()   # wait until SEM_LIMIT threads are in here simultaneously
+        with lock:
+            active[0] -= 1
+        return ({"elements": []}, False)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock_fetch):
+        sem = threading.Semaphore(SEM_LIMIT)
+        result = _fetch_tiles_parallel(tasks, "WATER", sem, max_workers=SEM_LIMIT + 2)
+
+    assert peak[0] <= SEM_LIMIT, \
+        f"Semaphore({SEM_LIMIT}) should cap concurrency, but peak was {peak[0]}"
+    assert len(result) == len(tasks)
+
+
+# ---------------------------------------------------------------------------
+# B1 — coloring_main signature
+# ---------------------------------------------------------------------------
+
+def test_coloring_main_has_prefetched_tiles_param():
+    import inspect
+    from TrailPrint3D.utils.terrain import coloring_main
+
+    sig = inspect.signature(coloring_main)
+    assert "prefetched_tiles" in sig.parameters, \
+        "coloring_main is missing the prefetched_tiles parameter"
+    assert sig.parameters["prefetched_tiles"].default is None, \
+        "prefetched_tiles default should be None"
+
+
+# ---------------------------------------------------------------------------
+# A1 — bmesh flood-fill loose-part splitting algorithm
+# (The same algorithm used in _split_loose inside _process_coloring_object)
+# ---------------------------------------------------------------------------
+
+def _flood_fill_components(bm_src):
+    """Return a list of vertex sets, one per connected component.
+    Uses Python object identity as the set key, which avoids the .index
+    invalidation that occurs when a bmesh is built directly (without a
+    to_mesh / from_mesh round-trip).
+    """
+    visited = set()   # contains BMVert Python objects (by identity)
+    components = []
+    for start in bm_src.verts:
+        if start in visited:
+            continue
+        comp = set()
+        stack = [start]
+        while stack:
+            v = stack.pop()
+            if v in visited:
+                continue
+            visited.add(v)
+            comp.add(v)
+            for edge in v.link_edges:
+                other = edge.other_vert(v)
+                if other not in visited:
+                    stack.append(other)
+        components.append(comp)
+    return components
+
+
+def test_split_loose_two_disconnected_triangles():
+    bm = bmesh.new()
+    # Triangle A
+    v0 = bm.verts.new((0.0, 0.0, 0.0))
+    v1 = bm.verts.new((1.0, 0.0, 0.0))
+    v2 = bm.verts.new((0.0, 1.0, 0.0))
+    bm.faces.new([v0, v1, v2])
+    # Triangle B — completely disconnected (different position, no shared verts)
+    v3 = bm.verts.new((10.0, 0.0, 0.0))
+    v4 = bm.verts.new((11.0, 0.0, 0.0))
+    v5 = bm.verts.new((10.0, 1.0, 0.0))
+    bm.faces.new([v3, v4, v5])
+
+    components = _flood_fill_components(bm)
+    bm.free()
+
+    assert len(components) == 2, f"Expected 2 components, got {len(components)}"
+    sizes = sorted(len(c) for c in components)
+    assert sizes == [3, 3], f"Expected component sizes [3,3], got {sizes}"
+
+
+def test_split_loose_single_connected_mesh():
+    bm = bmesh.new()
+    v0 = bm.verts.new((0.0, 0.0, 0.0))
+    v1 = bm.verts.new((1.0, 0.0, 0.0))
+    v2 = bm.verts.new((1.0, 1.0, 0.0))
+    v3 = bm.verts.new((0.0, 1.0, 0.0))
+    bm.faces.new([v0, v1, v2, v3])
+
+    components = _flood_fill_components(bm)
+    bm.free()
+
+    assert len(components) == 1, f"Expected 1 component, got {len(components)}"
+
+
+def test_split_loose_three_islands():
+    bm = bmesh.new()
+    for offset in [0.0, 5.0, 10.0]:
+        va = bm.verts.new((offset,       0.0, 0.0))
+        vb = bm.verts.new((offset + 1.0, 0.0, 0.0))
+        vc = bm.verts.new((offset,       1.0, 0.0))
+        bm.faces.new([va, vb, vc])
+
+    components = _flood_fill_components(bm)
+    bm.free()
+
+    assert len(components) == 3, f"Expected 3 components, got {len(components)}"
+
+
+def test_split_loose_produces_correct_objects_in_scene():
+    """End-to-end: build mesh object → run _split_loose logic → verify N objects."""
+    # Build a mesh with two disconnected quads and link it to the scene
+    mesh = bpy.data.meshes.new("_test_split_src")
+    bm = bmesh.new()
+    for x_off in [0.0, 20.0]:   # 20 units apart = definitely disconnected
+        va = bm.verts.new((x_off,       0.0, 0.0))
+        vb = bm.verts.new((x_off + 1.0, 0.0, 0.0))
+        vc = bm.verts.new((x_off + 1.0, 1.0, 0.0))
+        vd = bm.verts.new((x_off,       1.0, 0.0))
+        bm.faces.new([va, vb, vc, vd])
+    bm.to_mesh(mesh)
+    bm.free()
+
+    obj = bpy.data.objects.new("_test_split_obj", mesh)
+    col = bpy.context.scene.collection
+    col.objects.link(obj)
+
+    # --- replicate _split_loose from terrain.py (adapted for object-identity sets) ---
+    bm_src = bmesh.new()
+    bm_src.from_mesh(obj.data)
+    components = _flood_fill_components(bm_src)
+    world_matrix = obj.matrix_world.copy()
+    parts = []
+    for comp_verts in components:
+        comp_faces = [f for f in bm_src.faces
+                      if all(v in comp_verts for v in f.verts)]
+        bm_new = bmesh.new()
+        vert_map = {}
+        for v in comp_verts:
+            nv = bm_new.verts.new(v.co.copy())
+            vert_map[v] = nv
+        bm_new.verts.ensure_lookup_table()
+        for f in comp_faces:
+            try:
+                bm_new.faces.new([vert_map[v] for v in f.verts])
+            except ValueError:
+                pass
+        new_mesh = bpy.data.meshes.new(obj.name)
+        bm_new.to_mesh(new_mesh)
+        bm_new.free()
+        part = bpy.data.objects.new(obj.name, new_mesh)
+        part.matrix_world = world_matrix
+        col.objects.link(part)
+        parts.append(part)
+    bm_src.free()
+    bpy.data.objects.remove(obj, do_unlink=True)
+
+    assert len(parts) == 2, f"Expected 2 part objects, got {len(parts)}"
+    for p in parts:
+        assert len(p.data.vertices) == 4, \
+            f"Each part should have 4 verts, got {len(p.data.vertices)}"
+        bpy.data.objects.remove(p, do_unlink=True)
+
+
+# ---------------------------------------------------------------------------
+# A2 — bmesh ribbon merge
+# ---------------------------------------------------------------------------
+
+def _make_quad_object(name, x_offset):
+    mesh = bpy.data.meshes.new(name)
+    bm = bmesh.new()
+    x = x_offset
+    v0 = bm.verts.new((x,       0.0, 0.0))
+    v1 = bm.verts.new((x + 1.0, 0.0, 0.0))
+    v2 = bm.verts.new((x + 1.0, 1.0, 0.0))
+    v3 = bm.verts.new((x,       1.0, 0.0))
+    bm.faces.new([v0, v1, v2, v3])
+    bm.to_mesh(mesh)
+    bm.free()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+    return obj
+
+
+def test_ribbon_merge_vertex_count():
+    """Two 4-vert ribbons merged → 8 verts in the result mesh."""
+    r0 = _make_quad_object("_test_ribbon0", 0.0)
+    r1 = _make_quad_object("_test_ribbon1", 5.0)
+
+    # --- replicate A2 merge logic from terrain.py ---
+    bm_merged = bmesh.new()
+    target_world_inv = r0.matrix_world.inverted()
+    bm_merged.from_mesh(r0.data)
+
+    bm_part = bmesh.new()
+    bm_part.from_mesh(r1.data)
+    xform = target_world_inv @ r1.matrix_world
+    bmesh.ops.transform(bm_part, verts=bm_part.verts[:], matrix=xform)
+    tmp = bpy.data.meshes.new("_test_ribbon_tmp")
+    bm_part.to_mesh(tmp)
+    bm_part.free()
+    bm_merged.from_mesh(tmp)
+    bpy.data.meshes.remove(tmp)
+    bpy.data.objects.remove(r1, do_unlink=True)
+
+    bm_merged.to_mesh(r0.data)
+    bm_merged.free()
+    r0.name = "OpenObject_merged"
+
+    assert len(r0.data.vertices) == 8, \
+        f"Expected 8 verts after merge, got {len(r0.data.vertices)}"
+    assert len(r0.data.polygons) == 2, \
+        f"Expected 2 faces after merge, got {len(r0.data.polygons)}"
+
+    bpy.data.objects.remove(r0, do_unlink=True)
+
+
+def test_ribbon_merge_single_ribbon_is_unchanged():
+    """Single ribbon: no merge needed, object renamed and returned as-is."""
+    r0 = _make_quad_object("_test_ribbon_single", 0.0)
+    original_vert_count = len(r0.data.vertices)
+
+    # Simulate the len == 1 fast path from terrain.py
+    valid_ribbons = [r0]
+    if len(valid_ribbons) == 1:
+        valid_ribbons[0].name = "OpenObject_merged"
+
+    assert r0.name == "OpenObject_merged"
+    assert len(r0.data.vertices) == original_vert_count, \
+        "Single ribbon should be unchanged"
+
+    bpy.data.objects.remove(r0, do_unlink=True)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+# B3 — _fetch_all_kinds_parallel  (cross-kind parallel fetch)
+# ---------------------------------------------------------------------------
+
+def test_fetch_all_kinds_fetches_every_kind():
+    """Every requested kind must appear in the result dict."""
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
+
+    tasks = [(0.0, 0.0, 2.0, 2.0)]
+    kinds = ["WATER", "FOREST", "SCREE"]
+    kind_task_pairs = [(k, tasks) for k in kinds]
+
+    def _mock(bbox, kind, return_cache_status=False):
+        return ({"elements": []}, True)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+        result = _fetch_all_kinds_parallel(kind_task_pairs, threading.Semaphore(4))
+
+    for k in kinds:
+        assert k in result, f"Kind {k} missing from result"
+        assert tasks[0] in result[k], f"Tile missing for kind {k}"
+
+
+def test_fetch_all_kinds_failed_kind_excluded():
+    """A kind whose fetch returns None must have an empty dict in the result."""
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
+
+    tasks = [(0.0, 0.0, 2.0, 2.0)]
+
+    def _mock(bbox, kind, return_cache_status=False):
+        if kind == "WATER":
+            return ({"elements": []}, False)
+        return None  # FOREST fails
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+        result = _fetch_all_kinds_parallel(
+            [("WATER", tasks), ("FOREST", tasks)],
+            threading.Semaphore(4),
+        )
+
+    assert tasks[0] in result["WATER"], "Successful kind should have its tile"
+    assert result["FOREST"] == {}, "Failed kind should be an empty dict"
+
+
+def test_fetch_all_kinds_actually_concurrent():
+    """All kinds must be in-flight simultaneously (barrier proof)."""
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
+
+    N_KINDS = 4
+    barrier = threading.Barrier(N_KINDS, timeout=5)
+    tasks   = [(0.0, 0.0, 2.0, 2.0)]
+    kind_task_pairs = [(f"KIND{i}", tasks) for i in range(N_KINDS)]
+
+    def _mock(bbox, kind, return_cache_status=False):
+        barrier.wait()   # all N_KINDS threads must be here simultaneously
+        return ({"elements": []}, False)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+        result = _fetch_all_kinds_parallel(
+            kind_task_pairs,
+            threading.Semaphore(N_KINDS),   # semaphore not the bottleneck
+            max_workers=N_KINDS,
+        )
+
+    assert len(result) == N_KINDS
+
+
+def test_fetch_all_kinds_semaphore_caps_concurrency():
+    """Shared semaphore must limit peak across ALL kinds combined."""
+    import threading
+    from unittest.mock import patch
+    from TrailPrint3D.utils.terrain import _fetch_all_kinds_parallel
+
+    SEM_LIMIT = 2
+    active = [0]
+    peak   = [0]
+    lock   = threading.Lock()
+    gate   = threading.Barrier(SEM_LIMIT, timeout=5)
+
+    tasks = [(0.0, 0.0, 2.0, 2.0)]
+    # 6 kinds × 1 tile = 6 total tasks, semaphore(2) should cap to ≤ 2
+    kind_task_pairs = [(f"KIND{i}", tasks) for i in range(6)]
+
+    def _mock(bbox, kind, return_cache_status=False):
+        with lock:
+            active[0] += 1
+            peak[0] = max(peak[0], active[0])
+        gate.wait()
+        with lock:
+            active[0] -= 1
+        return ({"elements": []}, False)
+
+    with patch("TrailPrint3D.utils.osm.fetch_osm_data", _mock):
+        result = _fetch_all_kinds_parallel(
+            kind_task_pairs,
+            threading.Semaphore(SEM_LIMIT),
+            max_workers=SEM_LIMIT + 4,
+        )
+
+    assert peak[0] <= SEM_LIMIT, \
+        f"Semaphore({SEM_LIMIT}) exceeded: peak was {peak[0]}"
+    assert len(result) == 6
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("\n" + "=" * 60)
+    print("  TrailPrint3D — osm-threading-pr test suite")
+    print("=" * 60 + "\n")
+
+    # A3 — _overpass_request
+    _run("A3  success on first try",            test_overpass_request_success_first_try)
+    _run("A3  retry on 4xx then succeed",        test_overpass_request_retries_then_succeeds)
+    _run("A3  exhausted retries → None",         test_overpass_request_exhausted_returns_none)
+    _run("A3  Timeout triggers retry",           test_overpass_request_timeout_triggers_retry)
+    _run("A3  log_callback fired on error",      test_overpass_request_log_callback_called_on_error)
+    _run("A3  GET method uses requests.get",     test_overpass_request_get_method)
+
+    # B2 — _fetch_tiles_parallel
+    _run("B2  all tiles fetched",                test_fetch_tiles_parallel_all_tiles_fetched)
+    _run("B2  failed tile excluded from result", test_fetch_tiles_parallel_failed_tile_excluded)
+    _run("B2  result carries from_cache flag",   test_fetch_tiles_parallel_result_carries_cache_flag)
+    _run("B2  Semaphore(1) no deadlock",         test_fetch_tiles_parallel_respects_semaphore)
+    _run("B2  threads genuinely concurrent",     test_fetch_tiles_parallel_actually_concurrent)
+    _run("B2  semaphore caps peak concurrency",  test_fetch_tiles_parallel_semaphore_caps_concurrency)
+
+    # B3 — _fetch_all_kinds_parallel
+    _run("B3  all kinds fetched",                test_fetch_all_kinds_fetches_every_kind)
+    _run("B3  failed kind → empty dict",         test_fetch_all_kinds_failed_kind_excluded)
+    _run("B3  kinds genuinely concurrent",       test_fetch_all_kinds_actually_concurrent)
+    _run("B3  semaphore caps cross-kind concurrency", test_fetch_all_kinds_semaphore_caps_concurrency)
+
+    # B1 — coloring_main signature
+    _run("B1  prefetched_tiles param exists",    test_coloring_main_has_prefetched_tiles_param)
+
+    # A1 — bmesh split_loose algorithm
+    _run("A1  two disconnected triangles → 2",   test_split_loose_two_disconnected_triangles)
+    _run("A1  single connected mesh → 1",        test_split_loose_single_connected_mesh)
+    _run("A1  three islands → 3",                test_split_loose_three_islands)
+    _run("A1  end-to-end object creation",       test_split_loose_produces_correct_objects_in_scene)
+
+    # A2 — bmesh ribbon merge
+    _run("A2  two ribbons merged → 8 verts",     test_ribbon_merge_vertex_count)
+    _run("A2  single ribbon fast path",          test_ribbon_merge_single_ribbon_is_unchanged)
+
+    _assert_all_passed()


### PR DESCRIPTION
## What does this PR do?

Speeds up map generation by fetching all OSM tiles in parallel across all terrain kinds (WATER, CITY, GREENSPACE, FOREST, etc.) while the elevation data is loading, hiding most of the network round-trip time. Adds a centralised Overpass HTTP helper with automatic retry/backoff so transient 429s and timeouts no longer abort generation silently. Replaces several `bpy.ops`-based mesh operations (mode switches, join, separate) with direct bmesh equivalents to cut per-object overhead — most visibly in the coloring pipeline where 681 CITY objects were previously spending ~65 s on `recalculateNormals` mode switches alone.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->


## How was it tested?

Tested in Blender 5.1

## Checklist

- [x] I tested this in Blender 5.0 or newer
- [x] I haven't broken any existing features I'm aware of
- [ ] New or changed behaviour is reflected in the README (if relevant)