### PR TITLE
Remove 1 == 1 statement related to water generation

### DIFF
--- a/TrailPrint3D/utils/terrain.py
+++ b/TrailPrint3D/utils/terrain.py
@@ -267,7 +267,7 @@ def coloring_main(map, kind="WATER", prefetched_tiles=None):
                 for i, coords in enumerate(bodies):
                     blender_coords = [convert_to_blender_coordinates(lat, lon, ele, 0) for lat, lon, ele in coords]
                     calcArea = calculate_polygon_area_2d(blender_coords)
-                    if calcArea > col_Area or 1 == 1:
+                    if calcArea > col_Area:
                         tobj = col_create_face_mesh(f"Relation_{i}", blender_coords)
                         created_objects.append(tobj)
                         waterCreated += 1


### PR DESCRIPTION
## What does this PR do?

Removes a, what appears to be, leftover debug statement related to water generation.

This fix drastically decreases generating water.

Generating the map with water for a test GPX went from 162 seconds to just 23.
My original GPX (That is a roadtrip in Norway, which obviously has massive amounts of water) never even finished after running for 10 hours, and finishes within minutes after the change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Related issue

Closes #<!-- issue number, if any -->

## How was it tested?

Generating maps with the same GPX, with and without the change. The result seems to be the same, but the timing is drastically different.

## Checklist

- [x] I tested this in Blender 5.0 or newer > Only tested with Blender 5.1, but the change is so small I see no way this breaks on older Blender versions.
- [x] I haven't broken any existing features I'm aware of
- [x] New or changed behaviour is reflected in the README (if relevant)
