### PR TITLE
Enhance file picker; glob filter for .gpx

### DIFF
--- a/TrailPrint3D/__init__.py
+++ b/TrailPrint3D/__init__.py
@@ -161,6 +161,7 @@ classes = [
     operators.TP3D_OT_popup_pin,
     operators.TP3D_OT_popup_merge,
     operators.TP3D_OT_install_three_mf,
+    operators.TP3D_OT_pick_gpx_file,
     operators.TP3D_OT_check_update,
     operators.TP3D_OT_install_update,
 ]

--- a/TrailPrint3D/operators.py
+++ b/TrailPrint3D/operators.py
@@ -1735,6 +1735,23 @@ def _redraw_all_areas():
     return 0.5 if updater.status == "checking" else None
 
 
+class TP3D_OT_pick_gpx_file(bpy.types.Operator):
+    bl_idname = "tp3d.pick_gpx_file"
+    bl_label = "Use GPX File"
+    bl_description = "Use the selected GPX file"
+
+    filepath: StringProperty(subtype='FILE_PATH')  # type: ignore
+    filter_glob: StringProperty(default="*.gpx", options={'HIDDEN'})  # type: ignore
+
+    def execute(self, context):
+        context.scene.tp3d.file_path = self.filepath
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+
 class TP3D_OT_check_update(bpy.types.Operator):
     bl_idname = "tp3d.check_update"
     bl_label = "Check for Updates"

--- a/TrailPrint3D/panels.py
+++ b/TrailPrint3D/panels.py
@@ -120,7 +120,9 @@ class TP3D_PT_generate(bpy.types.Panel):
                 box.label(text=_("Files"), icon='FILE_FOLDER')
                 col = box.column(align=True)
                 if props.generation_mode == 'GENERATION':
-                    col.prop(props, "file_path")
+                    row = col.row(align=True)
+                    row.prop(props, "file_path", text=_("GPX File"))
+                    row.operator("tp3d.pick_gpx_file", text="", icon='FILEBROWSER')
                 elif temp.PREMIUMVERSION:
                     col.prop(props, "chain_path")
                 else:

--- a/TrailPrint3D/props.py
+++ b/TrailPrint3D/props.py
@@ -34,10 +34,9 @@ def generation_mode_update(self, context):
 class TP3D_PG_properties(bpy.types.PropertyGroup):
     file_path: StringProperty(
         name= _("File Path"),
-        description= _("Select a file"),
+        description= _("Select a GPX file"),
         default="",
         maxlen=1024,
-        subtype='FILE_PATH'  # Enables file selection
     )# type: ignore
     export_path: StringProperty(
         name= _("Export Path"),


### PR DESCRIPTION
## What does this PR do?

Introduces `TP3D_OT_pick_gpx_file` operator to open a file browser (filters *.gpx) and assign the chosen path to scene.tp3d.file_path. Register the new operator in the add-on classes list. Update the generate panel to show a file-browser button next to the file_path field for GPX selection. Clarify the file_path property description to "Select a GPX file" and remove the FILE_PATH subtype comment.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Related issue

None

## How was it tested?

Tested in 4.5 and 5.2, file picker opens and filters for `.gpx` files.

## Checklist

- [x] I tested this in Blender 5.0 or newer
- [x] I haven't broken any existing features I'm aware of
- [ ] New or changed behaviour is reflected in the README (if relevant)
