### PR TITLE
Fix discarded elevation outlier correction inflating map height

### DIFF
--- a/TrailPrint3D/utils/elevation.py
+++ b/TrailPrint3D/utils/elevation.py
@@ -759,6 +759,10 @@ def get_tile_elevation(obj, progress_cb=None):
             elevations = list(struct.unpack_from(f"<{_n}f", _raw, 4))
             if len(elevations) == len(world_verts):
                 print(f"Elevation cache hit ({_n} verts) — skipping API fetch")
+                elevations, _fixed_count = fix_invalid_elevations(elevations)
+                if _fixed_count > 0:
+                    print(f"Fixed {_fixed_count} invalid cached elevation value(s)")
+                    bpy.context.scene.tp3d.buggyDataset = 1
                 lowestElevation = min(elevations)
                 highestElevation = max(elevations)
                 additionalExtrusion = lowestElevation
@@ -795,7 +799,7 @@ def get_tile_elevation(obj, progress_cb=None):
         # Free memory after processing chunk
         del chunk_elevations
 
-    elevations2, _fixed_count = fix_invalid_elevations(elevations)
+    elevations, _fixed_count = fix_invalid_elevations(elevations)
     if _fixed_count > 0:
         print(f"Fixed {_fixed_count} invalid elevation value(s)")
         bpy.context.scene.tp3d.buggyDataset = 1


### PR DESCRIPTION
## What does this PR do?

fix_invalid_elevations() returned a cleaned copy into 'elevations2', but every subsequent line kept using the original un-fixed 'elevations'. A single out-of-range vertex (e.g. a nodata sentinel) therefore survived into the mesh, dragging lowestZ/additionalExtrusion far below the real terrain. Floor-normalization then pinned that lone spike to minThickness, floating the entire model (land and ocean) tens of mm into the air.

- Assign the cleaned list back to 'elevations' so the fix is actually used for min/max, caching and the returned data.
- Also run the fix on the cache-hit path so already-cached bad datasets heal on the next generation instead of persisting.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Related issue

Closes #36 

## How was it tested?

Tested with the same file posted in the issue post:
<img width="925" height="619" alt="image" src="https://github.com/user-attachments/assets/563fa438-54e9-46a8-ab05-83654079fbc0" />
Now correctly fixes those problematic low verts
```cmd
Fixed 38 invalid elevation value(s)
additionalExtrusion: -0.6482498207430704
Lowest z: -0.6482498207430704
Highest z: 1.1407181575863605
```

## Checklist

- [x] I tested this in Blender 5.0 or newer
- [x] I haven't broken any existing features I'm aware of
- [ ] New or changed behaviour is reflected in the README (if relevant)
