### PR TITLE
Guard paint mode against zero road height

### DIFF
--- a/TrailPrint3D/panels.py
+++ b/TrailPrint3D/panels.py
@@ -359,6 +359,10 @@ class TP3D_PT_advanced(bpy.types.Panel):
                 col.prop(props, "el_sSmallActive", icon='CHECKBOX_HLT' if props.el_sSmallActive else 'CHECKBOX_DEHLT')
                 col.prop(props, "el_sServiceActive", icon='CHECKBOX_HLT' if props.el_sServiceActive else 'CHECKBOX_DEHLT')
                 col.prop(props, "el_sFootwaysActive", icon='CHECKBOX_HLT' if props.el_sFootwaysActive else 'CHECKBOX_DEHLT')
+                if props.elementMode == "PAINT" and _any_road and props.el_sHeight == 0:
+                    row = sub.row()
+                    row.alert = True
+                    row.label(text=_("Road Height must be > 0 in Paint mode"), icon='ERROR')
                 row = sub.row(align=True)
                 row.prop(props, "el_sMultiplier")
                 row.prop(props, "el_sHeight")

--- a/TrailPrint3D/utils/generation.py
+++ b/TrailPrint3D/utils/generation.py
@@ -95,6 +95,14 @@ def _rg_validate_inputs(flags):
     # --- Input validation ---
     from ..addon_preferences import get_prefs
     _ot_api_key = get_prefs().openTopographyApiKey
+
+    if elementMode == "PAINT" and el_sActive and tp3d.el_sHeight == 0:
+        show_message_box(
+            "Road Height is 0 in Paint mode — this produces degenerate geometry. "
+            "Set Road Height above 0 or disable roads."
+        )
+        return None
+
     if api == "OPENTOPOGRAPHY" and not _ot_api_key:
         print("No OPENTOPOGRAPHY API key entered")
         show_message_box(


### PR DESCRIPTION
## What does this PR do?

Adds a visible warning in the advanced panel when Paint mode has roads enabled with a road height of 0, and stops generation early in that case to avoid degenerate road geometry.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Related issue

N/A

## Checklist

- [X] I tested this in Blender 5.1 or newer
- [x] I haven't broken any existing features I'm aware of
- [ ] New or changed behaviour is reflected in the README (if relevant)
