### PR TITLE
Align SCM trail depth with other SCM depths

### DIFF
--- a/TrailPrint3D/utils/mesh_ops.py
+++ b/TrailPrint3D/utils/mesh_ops.py
@@ -1860,9 +1860,10 @@ def single_color_mode_curve(crv, map, keepTolTrail = False, cutDepth = 2, projec
     bottom_z = lowest_z - trailCutDepth
     top_z = bottom_z + 100.0  # tall enough to clear any terrain
     trail_height = bpy.context.scene.tp3d.singleColorModeHeight
-    # crv_thick must reach the map's own floor so it cuts full-depth road slabs.
-    map_floor_z = min((map.matrix_world @ Vector(c)).z for c in map.bound_box) - 1.0
-    thick_bottom_z = min(bottom_z, map_floor_z)
+    # The trail groove cuts to trailCutDepth below the surface, matching other
+    # SCM elements. Roads are excluded from the trail footprint in 2D before
+    # finalize_roads builds them, so no need to reach the map floor here.
+    thick_bottom_z = bottom_z
 
     verts, faces = [], []
     for poly in g2d.iter_polygons(ribbon):
@@ -1883,7 +1884,7 @@ def single_color_mode_curve(crv, map, keepTolTrail = False, cutDepth = 2, projec
             _extrude_flat_polygon(g2d, poly, thick_bottom_z, top_z, t_verts, t_faces)
 
     print(f"[TP3D trail] earcut prism: {len(verts)} verts, {len(faces)} faces  bottom_z={bottom_z:.3f}")
-    print(f"[TP3D trail] thick earcut prism: {len(t_verts)} verts, {len(t_faces)} faces  thick_bottom_z={thick_bottom_z:.3f} map_floor_z={map_floor_z:.3f}")
+    print(f"[TP3D trail] thick earcut prism: {len(t_verts)} verts, {len(t_faces)} faces  thick_bottom_z={thick_bottom_z:.3f}")
 
     # Convert crv to MESH in place (preserves object identity -- other code
     # holds references to this exact object for later material/metadata


### PR DESCRIPTION
## What does this PR do?

Updated `single_color_mode_curve` to stop extending the thick road-cut prism to the map floor and instead use the same `bottom_z`/`trailCutDepth` depth as other single-color-mode trail cuts. This matches the current 2D exclusion flow before `finalize_roads`, and removes the now-unused map-floor calculation from debug output.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Related issue

N/A

## How was it tested?

Ran a quick generation with scm trail, no longer cuts through the entire map
<img width="1201" height="413" alt="image" src="https://github.com/user-attachments/assets/a3cb94f1-9305-4699-ac2f-36df759bc5c7" />
<img width="912" height="556" alt="image" src="https://github.com/user-attachments/assets/3c81eff0-0d95-429c-b1dd-33de65dbf822" />


## Checklist

- [x] I tested this in Blender 5.1 or newer
- [x] I haven't broken any existing features I'm aware of
- [ ] New or changed behaviour is reflected in the README (if relevant)
